### PR TITLE
Support SoftFloat canonical types on arm64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.10)
+
 # Defines softfloat library
 project (SoftFloat )
 
@@ -7,6 +9,27 @@ set (CMAKE_EXPORT_COMPILE_COMMANDS "ON")
 message ( STATUS "Configuring SoftFloat" )
 set( C_DEFINES "-DSOFTFLOAT_FAST_INT64 -DSOFTFLOAT_ROUND_EVEN -DINLINE_LEVEL=5 -DSOFTFLOAT_FAST_DIV32TO16 -DSOFTFLOAT_FAST_DIV64TO32" )
 set( CMAKE_C_FLAGS " -Wall -Werror-implicit-function-declaration -Wno-conversion ${CMAKE_C_FLAGS} ${C_DEFINES}" )
+
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "wasm|wasm32|wasm64")
+   message(STATUS "Configuring for wasm")
+   set(ARCH_SOURCE_TYPE 8086-SSE)
+   set(ARCH_BUILD_TYPE Linux-x86_64-GCC)
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64|amd64|x64")
+   message(STATUS "Configuring for x86_64")
+   set(ARCH_SOURCE_TYPE 8086-SSE)
+   set(ARCH_BUILD_TYPE Linux-x86_64-GCC)
+elseif(MSVC AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|ARM64|aarch64")
+   message(STATUS "Configuring for Windows ARM64 with generic ARM sources")
+   set(ARCH_SOURCE_TYPE ARM-VFPv2)
+   set(ARCH_BUILD_TYPE template-FAST_INT64)
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|ARM64|aarch64")
+   message(STATUS "Configuring for arm64")
+   set(ARCH_SOURCE_TYPE ARM-VFPv2)
+   set(ARCH_BUILD_TYPE Linux-ARM-VFPv2-GCC)
+else()
+   message(FATAL_ERROR "Unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
+endif()
+
 set ( softfloat_sources
   source/s_eq128.c
   source/s_le128.c
@@ -39,24 +62,24 @@ set ( softfloat_sources
   source/s_approxRecip32_1.c
   source/s_approxRecipSqrt_1Ks.c
   source/s_approxRecipSqrt32_1.c
-  source/8086-SSE/softfloat_raiseFlags.c
-  source/8086-SSE/s_f16UIToCommonNaN.c
-  source/8086-SSE/s_commonNaNToF16UI.c
-  source/8086-SSE/s_propagateNaNF16UI.c
-  source/8086-SSE/s_f32UIToCommonNaN.c
-  source/8086-SSE/s_commonNaNToF32UI.c
-  source/8086-SSE/s_propagateNaNF32UI.c
-  source/8086-SSE/s_f64UIToCommonNaN.c
-  source/8086-SSE/s_commonNaNToF64UI.c
-  source/8086-SSE/s_propagateNaNF64UI.c
-  source/8086-SSE/extF80M_isSignalingNaN.c
-  source/8086-SSE/s_extF80UIToCommonNaN.c
-  source/8086-SSE/s_commonNaNToExtF80UI.c
-  source/8086-SSE/s_propagateNaNExtF80UI.c
-  source/8086-SSE/f128M_isSignalingNaN.c
-  source/8086-SSE/s_f128UIToCommonNaN.c
-  source/8086-SSE/s_commonNaNToF128UI.c
-  source/8086-SSE/s_propagateNaNF128UI.c
+  source/${ARCH_SOURCE_TYPE}/softfloat_raiseFlags.c
+  source/${ARCH_SOURCE_TYPE}/s_f16UIToCommonNaN.c
+  source/${ARCH_SOURCE_TYPE}/s_commonNaNToF16UI.c
+  source/${ARCH_SOURCE_TYPE}/s_propagateNaNF16UI.c
+  source/${ARCH_SOURCE_TYPE}/s_f32UIToCommonNaN.c
+  source/${ARCH_SOURCE_TYPE}/s_commonNaNToF32UI.c
+  source/${ARCH_SOURCE_TYPE}/s_propagateNaNF32UI.c
+  source/${ARCH_SOURCE_TYPE}/s_f64UIToCommonNaN.c
+  source/${ARCH_SOURCE_TYPE}/s_commonNaNToF64UI.c
+  source/${ARCH_SOURCE_TYPE}/s_propagateNaNF64UI.c
+  source/${ARCH_SOURCE_TYPE}/extF80M_isSignalingNaN.c
+  source/${ARCH_SOURCE_TYPE}/s_extF80UIToCommonNaN.c
+  source/${ARCH_SOURCE_TYPE}/s_commonNaNToExtF80UI.c
+  source/${ARCH_SOURCE_TYPE}/s_propagateNaNExtF80UI.c
+  source/${ARCH_SOURCE_TYPE}/f128M_isSignalingNaN.c
+  source/${ARCH_SOURCE_TYPE}/s_f128UIToCommonNaN.c
+  source/${ARCH_SOURCE_TYPE}/s_commonNaNToF128UI.c
+  source/${ARCH_SOURCE_TYPE}/s_propagateNaNF128UI.c
   source/s_roundToUI32.c
   source/s_roundToUI64.c
   source/s_roundToI32.c
@@ -313,11 +336,41 @@ set ( softfloat_sources
 )
 
 file ( GLOB softfloat_headers "${CMAKE_CURRENT_SOURCE_DIR}/source/include/*.h"
-                              "${CMAKE_CURRENT_SOURCE_DIR}/build/Linux-x86_64-GCC/platform.h"
-                              "${CMAKE_CURRENT_SOURCE_DIR}/source/8086-SSE/specialize.h" )
+                              "${CMAKE_CURRENT_SOURCE_DIR}/build/${ARCH_BUILD_TYPE}/platform.h"
+                              "${CMAKE_CURRENT_SOURCE_DIR}/source/${ARCH_SOURCE_TYPE}/specialize.h" )
 list( APPEND softfloat_sources ${softfloat_headers} )
 add_library ( softfloat STATIC ${softfloat_sources} )
-target_include_directories( softfloat PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/source/include" "${CMAKE_CURRENT_SOURCE_DIR}/source/8086-SSE" "${CMAKE_CURRENT_SOURCE_DIR}/build/Linux-x86_64-GCC" )
+target_include_directories( softfloat PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/source/include" "${CMAKE_CURRENT_SOURCE_DIR}/source/${ARCH_SOURCE_TYPE}" "${CMAKE_CURRENT_SOURCE_DIR}/build/${ARCH_BUILD_TYPE}" )
+target_compile_options(softfloat PRIVATE
+   $<$<COMPILE_LANG_AND_ID:C,AppleClang,Clang,GNU>:-Wno-unused-label>
+)
+
+if((APPLE OR CMAKE_SYSTEM_NAME STREQUAL "Linux") AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|ARM64|aarch64")
+   target_compile_definitions(softfloat INTERFACE
+      SOFTFLOAT_DISABLE_LEGACY_TYPE_ALIASES
+   )
+
+   file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/include/softfloat")
+   configure_file(
+      "${CMAKE_CURRENT_SOURCE_DIR}/source/include/softfloat.hpp"
+      "${CMAKE_CURRENT_BINARY_DIR}/include/softfloat/softfloat.hpp"
+      COPYONLY
+   )
+   configure_file(
+      "${CMAKE_CURRENT_SOURCE_DIR}/source/include/softfloat_types.h"
+      "${CMAKE_CURRENT_BINARY_DIR}/include/softfloat_types.h"
+      COPYONLY
+   )
+   add_executable(softfloat_neon_include_order_test
+      tests/softfloat_neon_include_order_test.cpp
+      tests/softfloat_neon_include_order_reverse_test.cpp
+   )
+   target_include_directories(softfloat_neon_include_order_test PRIVATE
+      "${CMAKE_CURRENT_BINARY_DIR}/include"
+      "${CMAKE_CURRENT_SOURCE_DIR}/source/include"
+   )
+   target_link_libraries(softfloat_neon_include_order_test PRIVATE softfloat)
+endif()
 
 if(SOFTFLOAT_INSTALL_COMPONENT)
    set(INSTALL_COMPONENT_ARGS COMPONENT ${SOFTFLOAT_INSTALL_COMPONENT} EXCLUDE_FROM_ALL)

--- a/source/8086-SSE/f128M_isSignalingNaN.c
+++ b/source/8086-SSE/f128M_isSignalingNaN.c
@@ -42,7 +42,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /*----------------------------------------------------------------------------
 *----------------------------------------------------------------------------*/
-bool f128M_isSignalingNaN( const float128_t *aPtr )
+bool f128M_isSignalingNaN( const softfloat128_t *aPtr )
 {
     const uint32_t *aWPtr;
     uint32_t uiA96;

--- a/source/8086-SSE/s_f128MToCommonNaN.c
+++ b/source/8086-SSE/s_f128MToCommonNaN.c
@@ -52,7 +52,7 @@ void
  softfloat_f128MToCommonNaN( const uint32_t *aWPtr, struct commonNaN *zPtr )
 {
 
-    if ( f128M_isSignalingNaN( (const float128_t *) aWPtr ) ) {
+    if ( f128M_isSignalingNaN( (const softfloat128_t *) aWPtr ) ) {
         softfloat_raiseFlags( softfloat_flag_invalid );
     }
     zPtr->sign = aWPtr[indexWordHi( 4 )]>>31;

--- a/source/8086-SSE/s_propagateNaNF128M.c
+++ b/source/8086-SSE/s_propagateNaNF128M.c
@@ -57,10 +57,10 @@ void
     const uint32_t *ptr;
 
     ptr = aWPtr;
-    isSigNaNA = f128M_isSignalingNaN( (const float128_t *) aWPtr );
+    isSigNaNA = f128M_isSignalingNaN( (const softfloat128_t *) aWPtr );
     if (
         isSigNaNA
-            || (bWPtr && f128M_isSignalingNaN( (const float128_t *) bWPtr ))
+            || (bWPtr && f128M_isSignalingNaN( (const softfloat128_t *) bWPtr ))
     ) {
         softfloat_raiseFlags( softfloat_flag_invalid );
         if ( isSigNaNA ) goto copy;

--- a/source/8086/f128M_isSignalingNaN.c
+++ b/source/8086/f128M_isSignalingNaN.c
@@ -42,7 +42,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /*----------------------------------------------------------------------------
 *----------------------------------------------------------------------------*/
-bool f128M_isSignalingNaN( const float128_t *aPtr )
+bool f128M_isSignalingNaN( const softfloat128_t *aPtr )
 {
     const uint32_t *aWPtr;
     uint32_t uiA96;

--- a/source/8086/s_f128MToCommonNaN.c
+++ b/source/8086/s_f128MToCommonNaN.c
@@ -52,7 +52,7 @@ void
  softfloat_f128MToCommonNaN( const uint32_t *aWPtr, struct commonNaN *zPtr )
 {
 
-    if ( f128M_isSignalingNaN( (const float128_t *) aWPtr ) ) {
+    if ( f128M_isSignalingNaN( (const softfloat128_t *) aWPtr ) ) {
         softfloat_raiseFlags( softfloat_flag_invalid );
     }
     zPtr->sign = aWPtr[indexWordHi( 4 )]>>31;

--- a/source/8086/s_propagateNaNF128M.c
+++ b/source/8086/s_propagateNaNF128M.c
@@ -58,13 +58,13 @@ void
     bool isSigNaNB;
     uint32_t uiA96, uiB96, wordMagA, wordMagB;
 
-    isSigNaNA = f128M_isSignalingNaN( (const float128_t *) aWPtr );
+    isSigNaNA = f128M_isSignalingNaN( (const softfloat128_t *) aWPtr );
     ptr = aWPtr;
     if ( ! bWPtr ) {
         if ( isSigNaNA ) softfloat_raiseFlags( softfloat_flag_invalid );
         goto copy;
     }
-    isSigNaNB = f128M_isSignalingNaN( (const float128_t *) bWPtr );
+    isSigNaNB = f128M_isSignalingNaN( (const softfloat128_t *) bWPtr );
     if ( isSigNaNA | isSigNaNB ) {
         softfloat_raiseFlags( softfloat_flag_invalid );
         if ( isSigNaNA ) {

--- a/source/ARM-VFPv2-defaultNaN/f128M_isSignalingNaN.c
+++ b/source/ARM-VFPv2-defaultNaN/f128M_isSignalingNaN.c
@@ -42,7 +42,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /*----------------------------------------------------------------------------
 *----------------------------------------------------------------------------*/
-bool f128M_isSignalingNaN( const float128_t *aPtr )
+bool f128M_isSignalingNaN( const softfloat128_t *aPtr )
 {
     const uint32_t *aWPtr;
     uint32_t uiA96;

--- a/source/ARM-VFPv2-defaultNaN/s_propagateNaNF128M.c
+++ b/source/ARM-VFPv2-defaultNaN/s_propagateNaNF128M.c
@@ -54,8 +54,8 @@ void
 {
 
     if (
-        f128M_isSignalingNaN( (const float128_t *) aWPtr );
-            || (bWPtr && f128M_isSignalingNaN( (const float128_t *) bWPtr ))
+        f128M_isSignalingNaN( (const softfloat128_t *) aWPtr );
+            || (bWPtr && f128M_isSignalingNaN( (const softfloat128_t *) bWPtr ))
     ) {
         softfloat_raiseFlags( softfloat_flag_invalid );
     }

--- a/source/ARM-VFPv2/f128M_isSignalingNaN.c
+++ b/source/ARM-VFPv2/f128M_isSignalingNaN.c
@@ -42,7 +42,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /*----------------------------------------------------------------------------
 *----------------------------------------------------------------------------*/
-bool f128M_isSignalingNaN( const float128_t *aPtr )
+bool f128M_isSignalingNaN( const softfloat128_t *aPtr )
 {
     const uint32_t *aWPtr;
     uint32_t uiA96;

--- a/source/ARM-VFPv2/s_f128MToCommonNaN.c
+++ b/source/ARM-VFPv2/s_f128MToCommonNaN.c
@@ -52,7 +52,7 @@ void
  softfloat_f128MToCommonNaN( const uint32_t *aWPtr, struct commonNaN *zPtr )
 {
 
-    if ( f128M_isSignalingNaN( (const float128_t *) aWPtr ) ) {
+    if ( f128M_isSignalingNaN( (const softfloat128_t *) aWPtr ) ) {
         softfloat_raiseFlags( softfloat_flag_invalid );
     }
     zPtr->sign = aWPtr[indexWordHi( 4 )]>>31;

--- a/source/ARM-VFPv2/s_propagateNaNF128M.c
+++ b/source/ARM-VFPv2/s_propagateNaNF128M.c
@@ -57,10 +57,10 @@ void
     bool isSigNaNA;
 
     ptr = aWPtr;
-    isSigNaNA = f128M_isSignalingNaN( (const float128_t *) aWPtr );
+    isSigNaNA = f128M_isSignalingNaN( (const softfloat128_t *) aWPtr );
     if (
         isSigNaNA
-            || (bWPtr && f128M_isSignalingNaN( (const float128_t *) bWPtr ))
+            || (bWPtr && f128M_isSignalingNaN( (const softfloat128_t *) bWPtr ))
     ) {
         softfloat_raiseFlags( softfloat_flag_invalid );
         if ( ! isSigNaNA ) ptr = bWPtr;

--- a/source/RISCV/f128M_isSignalingNaN.c
+++ b/source/RISCV/f128M_isSignalingNaN.c
@@ -42,7 +42,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /*----------------------------------------------------------------------------
 *----------------------------------------------------------------------------*/
-bool f128M_isSignalingNaN( const float128_t *aPtr )
+bool f128M_isSignalingNaN( const softfloat128_t *aPtr )
 {
     const uint32_t *aWPtr;
     uint32_t uiA96;

--- a/source/RISCV/s_propagateNaNF128M.c
+++ b/source/RISCV/s_propagateNaNF128M.c
@@ -54,8 +54,8 @@ void
 {
 
     if (
-        f128M_isSignalingNaN( (const float128_t *) aWPtr );
-            || (bWPtr && f128M_isSignalingNaN( (const float128_t *) bWPtr ))
+        f128M_isSignalingNaN( (const softfloat128_t *) aWPtr );
+            || (bWPtr && f128M_isSignalingNaN( (const softfloat128_t *) bWPtr ))
     ) {
         softfloat_raiseFlags( softfloat_flag_invalid );
     }

--- a/source/extF80M_to_f128M.c
+++ b/source/extF80M_to_f128M.c
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef SOFTFLOAT_FAST_INT64
 
-void extF80M_to_f128M( const extFloat80_t *aPtr, float128_t *zPtr )
+void extF80M_to_f128M( const extFloat80_t *aPtr, softfloat128_t *zPtr )
 {
 
     *zPtr = extF80_to_f128( *aPtr );
@@ -52,7 +52,7 @@ void extF80M_to_f128M( const extFloat80_t *aPtr, float128_t *zPtr )
 
 #else
 
-void extF80M_to_f128M( const extFloat80_t *aPtr, float128_t *zPtr )
+void extF80M_to_f128M( const extFloat80_t *aPtr, softfloat128_t *zPtr )
 {
     const struct extFloat80M *aSPtr;
     uint32_t *zWPtr;

--- a/source/extF80M_to_f16.c
+++ b/source/extF80M_to_f16.c
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef SOFTFLOAT_FAST_INT64
 
-float16_t extF80M_to_f16( const extFloat80_t *aPtr )
+softfloat16_t extF80M_to_f16( const extFloat80_t *aPtr )
 {
 
     return extF80_to_f16( *aPtr );
@@ -52,7 +52,7 @@ float16_t extF80M_to_f16( const extFloat80_t *aPtr )
 
 #else
 
-float16_t extF80M_to_f16( const extFloat80_t *aPtr )
+softfloat16_t extF80M_to_f16( const extFloat80_t *aPtr )
 {
     const struct extFloat80M *aSPtr;
     uint_fast16_t uiA64;

--- a/source/extF80M_to_f32.c
+++ b/source/extF80M_to_f32.c
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef SOFTFLOAT_FAST_INT64
 
-float32_t extF80M_to_f32( const extFloat80_t *aPtr )
+softfloat32_t extF80M_to_f32( const extFloat80_t *aPtr )
 {
 
     return extF80_to_f32( *aPtr );
@@ -52,7 +52,7 @@ float32_t extF80M_to_f32( const extFloat80_t *aPtr )
 
 #else
 
-float32_t extF80M_to_f32( const extFloat80_t *aPtr )
+softfloat32_t extF80M_to_f32( const extFloat80_t *aPtr )
 {
     const struct extFloat80M *aSPtr;
     uint_fast16_t uiA64;

--- a/source/extF80M_to_f64.c
+++ b/source/extF80M_to_f64.c
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef SOFTFLOAT_FAST_INT64
 
-float64_t extF80M_to_f64( const extFloat80_t *aPtr )
+softfloat64_t extF80M_to_f64( const extFloat80_t *aPtr )
 {
 
     return extF80_to_f64( *aPtr );
@@ -52,7 +52,7 @@ float64_t extF80M_to_f64( const extFloat80_t *aPtr )
 
 #else
 
-float64_t extF80M_to_f64( const extFloat80_t *aPtr )
+softfloat64_t extF80M_to_f64( const extFloat80_t *aPtr )
 {
     const struct extFloat80M *aSPtr;
     uint_fast16_t uiA64;

--- a/source/extF80_to_f128.c
+++ b/source/extF80_to_f128.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float128_t extF80_to_f128( extFloat80_t a )
+softfloat128_t extF80_to_f128( extFloat80_t a )
 {
     union { struct extFloat80M s; extFloat80_t f; } uA;
     uint_fast16_t uiA64;

--- a/source/extF80_to_f16.c
+++ b/source/extF80_to_f16.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float16_t extF80_to_f16( extFloat80_t a )
+softfloat16_t extF80_to_f16( extFloat80_t a )
 {
     union { struct extFloat80M s; extFloat80_t f; } uA;
     uint_fast16_t uiA64;

--- a/source/extF80_to_f32.c
+++ b/source/extF80_to_f32.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float32_t extF80_to_f32( extFloat80_t a )
+softfloat32_t extF80_to_f32( extFloat80_t a )
 {
     union { struct extFloat80M s; extFloat80_t f; } uA;
     uint_fast16_t uiA64;

--- a/source/extF80_to_f64.c
+++ b/source/extF80_to_f64.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float64_t extF80_to_f64( extFloat80_t a )
+softfloat64_t extF80_to_f64( extFloat80_t a )
 {
     union { struct extFloat80M s; extFloat80_t f; } uA;
     uint_fast16_t uiA64;

--- a/source/f128M_add.c
+++ b/source/f128M_add.c
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef SOFTFLOAT_FAST_INT64
 
 void
- f128M_add( const float128_t *aPtr, const float128_t *bPtr, float128_t *zPtr )
+ f128M_add( const softfloat128_t *aPtr, const softfloat128_t *bPtr, softfloat128_t *zPtr )
 {
     const uint64_t *aWPtr, *bWPtr;
     uint_fast64_t uiA64, uiA0;
@@ -51,7 +51,7 @@ void
     uint_fast64_t uiB64, uiB0;
     bool signB;
 #if ! defined INLINE_LEVEL || (INLINE_LEVEL < 2)
-    float128_t
+    softfloat128_t
         (*magsFuncPtr)(
             uint_fast64_t, uint_fast64_t, uint_fast64_t, uint_fast64_t, bool );
 #endif
@@ -81,7 +81,7 @@ void
 #else
 
 void
- f128M_add( const float128_t *aPtr, const float128_t *bPtr, float128_t *zPtr )
+ f128M_add( const softfloat128_t *aPtr, const softfloat128_t *bPtr, softfloat128_t *zPtr )
 {
 
     softfloat_addF128M(

--- a/source/f128M_div.c
+++ b/source/f128M_div.c
@@ -44,7 +44,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef SOFTFLOAT_FAST_INT64
 
 void
- f128M_div( const float128_t *aPtr, const float128_t *bPtr, float128_t *zPtr )
+ f128M_div( const softfloat128_t *aPtr, const softfloat128_t *bPtr, softfloat128_t *zPtr )
 {
 
     *zPtr = f128_div( *aPtr, *bPtr );
@@ -54,7 +54,7 @@ void
 #else
 
 void
- f128M_div( const float128_t *aPtr, const float128_t *bPtr, float128_t *zPtr )
+ f128M_div( const softfloat128_t *aPtr, const softfloat128_t *bPtr, softfloat128_t *zPtr )
 {
     const uint32_t *aWPtr, *bWPtr;
     uint32_t *zWPtr, uiA96;

--- a/source/f128M_eq.c
+++ b/source/f128M_eq.c
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef SOFTFLOAT_FAST_INT64
 
-bool f128M_eq( const float128_t *aPtr, const float128_t *bPtr )
+bool f128M_eq( const softfloat128_t *aPtr, const softfloat128_t *bPtr )
 {
 
     return f128_eq( *aPtr, *bPtr );
@@ -52,7 +52,7 @@ bool f128M_eq( const float128_t *aPtr, const float128_t *bPtr )
 
 #else
 
-bool f128M_eq( const float128_t *aPtr, const float128_t *bPtr )
+bool f128M_eq( const softfloat128_t *aPtr, const softfloat128_t *bPtr )
 {
     const uint32_t *aWPtr, *bWPtr;
     uint32_t wordA, wordB, uiA96, uiB96;
@@ -87,8 +87,8 @@ bool f128M_eq( const float128_t *aPtr, const float128_t *bPtr )
     }
  false_checkSigNaNs:
     if (
-           f128M_isSignalingNaN( (const float128_t *) aWPtr )
-        || f128M_isSignalingNaN( (const float128_t *) bWPtr )
+           f128M_isSignalingNaN( (const softfloat128_t *) aWPtr )
+        || f128M_isSignalingNaN( (const softfloat128_t *) bWPtr )
     ) {
         softfloat_raiseFlags( softfloat_flag_invalid );
     }

--- a/source/f128M_eq_signaling.c
+++ b/source/f128M_eq_signaling.c
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef SOFTFLOAT_FAST_INT64
 
-bool f128M_eq_signaling( const float128_t *aPtr, const float128_t *bPtr )
+bool f128M_eq_signaling( const softfloat128_t *aPtr, const softfloat128_t *bPtr )
 {
 
     return f128_eq_signaling( *aPtr, *bPtr );
@@ -52,7 +52,7 @@ bool f128M_eq_signaling( const float128_t *aPtr, const float128_t *bPtr )
 
 #else
 
-bool f128M_eq_signaling( const float128_t *aPtr, const float128_t *bPtr )
+bool f128M_eq_signaling( const softfloat128_t *aPtr, const softfloat128_t *bPtr )
 {
     const uint32_t *aWPtr, *bWPtr;
     uint32_t wordA, wordB, uiA96, uiB96;

--- a/source/f128M_le.c
+++ b/source/f128M_le.c
@@ -42,7 +42,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef SOFTFLOAT_FAST_INT64
 
-bool f128M_le( const float128_t *aPtr, const float128_t *bPtr )
+bool f128M_le( const softfloat128_t *aPtr, const softfloat128_t *bPtr )
 {
 
     return f128_le( *aPtr, *bPtr );
@@ -51,7 +51,7 @@ bool f128M_le( const float128_t *aPtr, const float128_t *bPtr )
 
 #else
 
-bool f128M_le( const float128_t *aPtr, const float128_t *bPtr )
+bool f128M_le( const softfloat128_t *aPtr, const softfloat128_t *bPtr )
 {
     const uint32_t *aWPtr, *bWPtr;
     uint32_t uiA96, uiB96;

--- a/source/f128M_le_quiet.c
+++ b/source/f128M_le_quiet.c
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef SOFTFLOAT_FAST_INT64
 
-bool f128M_le_quiet( const float128_t *aPtr, const float128_t *bPtr )
+bool f128M_le_quiet( const softfloat128_t *aPtr, const softfloat128_t *bPtr )
 {
 
     return f128_le_quiet( *aPtr, *bPtr );
@@ -52,7 +52,7 @@ bool f128M_le_quiet( const float128_t *aPtr, const float128_t *bPtr )
 
 #else
 
-bool f128M_le_quiet( const float128_t *aPtr, const float128_t *bPtr )
+bool f128M_le_quiet( const softfloat128_t *aPtr, const softfloat128_t *bPtr )
 {
     const uint32_t *aWPtr, *bWPtr;
     uint32_t uiA96, uiB96;

--- a/source/f128M_lt.c
+++ b/source/f128M_lt.c
@@ -42,7 +42,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef SOFTFLOAT_FAST_INT64
 
-bool f128M_lt( const float128_t *aPtr, const float128_t *bPtr )
+bool f128M_lt( const softfloat128_t *aPtr, const softfloat128_t *bPtr )
 {
 
     return f128_lt( *aPtr, *bPtr );
@@ -51,7 +51,7 @@ bool f128M_lt( const float128_t *aPtr, const float128_t *bPtr )
 
 #else
 
-bool f128M_lt( const float128_t *aPtr, const float128_t *bPtr )
+bool f128M_lt( const softfloat128_t *aPtr, const softfloat128_t *bPtr )
 {
     const uint32_t *aWPtr, *bWPtr;
     uint32_t uiA96, uiB96;

--- a/source/f128M_lt_quiet.c
+++ b/source/f128M_lt_quiet.c
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef SOFTFLOAT_FAST_INT64
 
-bool f128M_lt_quiet( const float128_t *aPtr, const float128_t *bPtr )
+bool f128M_lt_quiet( const softfloat128_t *aPtr, const softfloat128_t *bPtr )
 {
 
     return f128_lt_quiet( *aPtr, *bPtr );
@@ -52,7 +52,7 @@ bool f128M_lt_quiet( const float128_t *aPtr, const float128_t *bPtr )
 
 #else
 
-bool f128M_lt_quiet( const float128_t *aPtr, const float128_t *bPtr )
+bool f128M_lt_quiet( const softfloat128_t *aPtr, const softfloat128_t *bPtr )
 {
     const uint32_t *aWPtr, *bWPtr;
     uint32_t uiA96, uiB96;

--- a/source/f128M_mul.c
+++ b/source/f128M_mul.c
@@ -44,7 +44,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef SOFTFLOAT_FAST_INT64
 
 void
- f128M_mul( const float128_t *aPtr, const float128_t *bPtr, float128_t *zPtr )
+ f128M_mul( const softfloat128_t *aPtr, const softfloat128_t *bPtr, softfloat128_t *zPtr )
 {
 
     *zPtr = f128_mul( *aPtr, *bPtr );
@@ -54,7 +54,7 @@ void
 #else
 
 void
- f128M_mul( const float128_t *aPtr, const float128_t *bPtr, float128_t *zPtr )
+ f128M_mul( const softfloat128_t *aPtr, const softfloat128_t *bPtr, softfloat128_t *zPtr )
 {
     const uint32_t *aWPtr, *bWPtr;
     uint32_t *zWPtr;

--- a/source/f128M_mulAdd.c
+++ b/source/f128M_mulAdd.c
@@ -43,10 +43,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 void
  f128M_mulAdd(
-     const float128_t *aPtr,
-     const float128_t *bPtr,
-     const float128_t *cPtr,
-     float128_t *zPtr
+     const softfloat128_t *aPtr,
+     const softfloat128_t *bPtr,
+     const softfloat128_t *cPtr,
+     softfloat128_t *zPtr
  )
 {
     const uint64_t *aWPtr, *bWPtr, *cWPtr;
@@ -71,10 +71,10 @@ void
 
 void
  f128M_mulAdd(
-     const float128_t *aPtr,
-     const float128_t *bPtr,
-     const float128_t *cPtr,
-     float128_t *zPtr
+     const softfloat128_t *aPtr,
+     const softfloat128_t *bPtr,
+     const softfloat128_t *cPtr,
+     softfloat128_t *zPtr
  )
 {
 

--- a/source/f128M_rem.c
+++ b/source/f128M_rem.c
@@ -44,7 +44,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef SOFTFLOAT_FAST_INT64
 
 void
- f128M_rem( const float128_t *aPtr, const float128_t *bPtr, float128_t *zPtr )
+ f128M_rem( const softfloat128_t *aPtr, const softfloat128_t *bPtr, softfloat128_t *zPtr )
 {
 
     *zPtr = f128_rem( *aPtr, *bPtr );
@@ -54,7 +54,7 @@ void
 #else
 
 void
- f128M_rem( const float128_t *aPtr, const float128_t *bPtr, float128_t *zPtr )
+ f128M_rem( const softfloat128_t *aPtr, const softfloat128_t *bPtr, softfloat128_t *zPtr )
 {
     const uint32_t *aWPtr, *bWPtr;
     uint32_t *zWPtr, uiA96;

--- a/source/f128M_roundToInt.c
+++ b/source/f128M_roundToInt.c
@@ -45,10 +45,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 void
  f128M_roundToInt(
-     const float128_t *aPtr,
+     const softfloat128_t *aPtr,
      uint_fast8_t roundingMode,
      bool exact,
-     float128_t *zPtr
+     softfloat128_t *zPtr
  )
 {
 
@@ -60,10 +60,10 @@ void
 
 void
  f128M_roundToInt(
-     const float128_t *aPtr,
+     const softfloat128_t *aPtr,
      uint_fast8_t roundingMode,
      bool exact,
-     float128_t *zPtr
+     softfloat128_t *zPtr
  )
 {
     const uint32_t *aWPtr;

--- a/source/f128M_sqrt.c
+++ b/source/f128M_sqrt.c
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef SOFTFLOAT_FAST_INT64
 
-void f128M_sqrt( const float128_t *aPtr, float128_t *zPtr )
+void f128M_sqrt( const softfloat128_t *aPtr, softfloat128_t *zPtr )
 {
 
     *zPtr = f128_sqrt( *aPtr );
@@ -52,7 +52,7 @@ void f128M_sqrt( const float128_t *aPtr, float128_t *zPtr )
 
 #else
 
-void f128M_sqrt( const float128_t *aPtr, float128_t *zPtr )
+void f128M_sqrt( const softfloat128_t *aPtr, softfloat128_t *zPtr )
 {
     const uint32_t *aWPtr;
     uint32_t *zWPtr;

--- a/source/f128M_sub.c
+++ b/source/f128M_sub.c
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef SOFTFLOAT_FAST_INT64
 
 void
- f128M_sub( const float128_t *aPtr, const float128_t *bPtr, float128_t *zPtr )
+ f128M_sub( const softfloat128_t *aPtr, const softfloat128_t *bPtr, softfloat128_t *zPtr )
 {
     const uint64_t *aWPtr, *bWPtr;
     uint_fast64_t uiA64, uiA0;
@@ -51,7 +51,7 @@ void
     uint_fast64_t uiB64, uiB0;
     bool signB;
 #if ! defined INLINE_LEVEL || (INLINE_LEVEL < 2)
-    float128_t
+    softfloat128_t
         (*magsFuncPtr)(
             uint_fast64_t, uint_fast64_t, uint_fast64_t, uint_fast64_t, bool );
 #endif
@@ -81,7 +81,7 @@ void
 #else
 
 void
- f128M_sub( const float128_t *aPtr, const float128_t *bPtr, float128_t *zPtr )
+ f128M_sub( const softfloat128_t *aPtr, const softfloat128_t *bPtr, softfloat128_t *zPtr )
 {
 
     softfloat_addF128M(

--- a/source/f128M_to_extF80M.c
+++ b/source/f128M_to_extF80M.c
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef SOFTFLOAT_FAST_INT64
 
-void f128M_to_extF80M( const float128_t *aPtr, extFloat80_t *zPtr )
+void f128M_to_extF80M( const softfloat128_t *aPtr, extFloat80_t *zPtr )
 {
 
     *zPtr = f128_to_extF80( *aPtr );
@@ -52,7 +52,7 @@ void f128M_to_extF80M( const float128_t *aPtr, extFloat80_t *zPtr )
 
 #else
 
-void f128M_to_extF80M( const float128_t *aPtr, extFloat80_t *zPtr )
+void f128M_to_extF80M( const softfloat128_t *aPtr, extFloat80_t *zPtr )
 {
     const uint32_t *aWPtr;
     struct extFloat80M *zSPtr;

--- a/source/f128M_to_f16.c
+++ b/source/f128M_to_f16.c
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef SOFTFLOAT_FAST_INT64
 
-float16_t f128M_to_f16( const float128_t *aPtr )
+softfloat16_t f128M_to_f16( const softfloat128_t *aPtr )
 {
 
     return f128_to_f16( *aPtr );
@@ -52,7 +52,7 @@ float16_t f128M_to_f16( const float128_t *aPtr )
 
 #else
 
-float16_t f128M_to_f16( const float128_t *aPtr )
+softfloat16_t f128M_to_f16( const softfloat128_t *aPtr )
 {
     const uint32_t *aWPtr;
     uint32_t uiA96;

--- a/source/f128M_to_f32.c
+++ b/source/f128M_to_f32.c
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef SOFTFLOAT_FAST_INT64
 
-float32_t f128M_to_f32( const float128_t *aPtr )
+softfloat32_t f128M_to_f32( const softfloat128_t *aPtr )
 {
 
     return f128_to_f32( *aPtr );
@@ -52,7 +52,7 @@ float32_t f128M_to_f32( const float128_t *aPtr )
 
 #else
 
-float32_t f128M_to_f32( const float128_t *aPtr )
+softfloat32_t f128M_to_f32( const softfloat128_t *aPtr )
 {
     const uint32_t *aWPtr;
     uint32_t uiA96;

--- a/source/f128M_to_f64.c
+++ b/source/f128M_to_f64.c
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef SOFTFLOAT_FAST_INT64
 
-float64_t f128M_to_f64( const float128_t *aPtr )
+softfloat64_t f128M_to_f64( const softfloat128_t *aPtr )
 {
 
     return f128_to_f64( *aPtr );
@@ -52,7 +52,7 @@ float64_t f128M_to_f64( const float128_t *aPtr )
 
 #else
 
-float64_t f128M_to_f64( const float128_t *aPtr )
+softfloat64_t f128M_to_f64( const softfloat128_t *aPtr )
 {
     const uint32_t *aWPtr;
     uint32_t uiA96;

--- a/source/f128M_to_i32.c
+++ b/source/f128M_to_i32.c
@@ -44,7 +44,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef SOFTFLOAT_FAST_INT64
 
 int_fast32_t
- f128M_to_i32( const float128_t *aPtr, uint_fast8_t roundingMode, bool exact )
+ f128M_to_i32( const softfloat128_t *aPtr, uint_fast8_t roundingMode, bool exact )
 {
 
     return f128_to_i32( *aPtr, roundingMode, exact );
@@ -54,7 +54,7 @@ int_fast32_t
 #else
 
 int_fast32_t
- f128M_to_i32( const float128_t *aPtr, uint_fast8_t roundingMode, bool exact )
+ f128M_to_i32( const softfloat128_t *aPtr, uint_fast8_t roundingMode, bool exact )
 {
     const uint32_t *aWPtr;
     uint32_t uiA96;

--- a/source/f128M_to_i32_r_minMag.c
+++ b/source/f128M_to_i32_r_minMag.c
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef SOFTFLOAT_FAST_INT64
 
-int_fast32_t f128M_to_i32_r_minMag( const float128_t *aPtr, bool exact )
+int_fast32_t f128M_to_i32_r_minMag( const softfloat128_t *aPtr, bool exact )
 {
 
     return f128_to_i32_r_minMag( *aPtr, exact );
@@ -52,7 +52,7 @@ int_fast32_t f128M_to_i32_r_minMag( const float128_t *aPtr, bool exact )
 
 #else
 
-int_fast32_t f128M_to_i32_r_minMag( const float128_t *aPtr, bool exact )
+int_fast32_t f128M_to_i32_r_minMag( const softfloat128_t *aPtr, bool exact )
 {
     const uint32_t *aWPtr;
     uint32_t uiA96;

--- a/source/f128M_to_i64.c
+++ b/source/f128M_to_i64.c
@@ -44,7 +44,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef SOFTFLOAT_FAST_INT64
 
 int_fast64_t
- f128M_to_i64( const float128_t *aPtr, uint_fast8_t roundingMode, bool exact )
+ f128M_to_i64( const softfloat128_t *aPtr, uint_fast8_t roundingMode, bool exact )
 {
 
     return f128_to_i64( *aPtr, roundingMode, exact );
@@ -54,7 +54,7 @@ int_fast64_t
 #else
 
 int_fast64_t
- f128M_to_i64( const float128_t *aPtr, uint_fast8_t roundingMode, bool exact )
+ f128M_to_i64( const softfloat128_t *aPtr, uint_fast8_t roundingMode, bool exact )
 {
     const uint32_t *aWPtr;
     uint32_t uiA96;

--- a/source/f128M_to_i64_r_minMag.c
+++ b/source/f128M_to_i64_r_minMag.c
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef SOFTFLOAT_FAST_INT64
 
-int_fast64_t f128M_to_i64_r_minMag( const float128_t *aPtr, bool exact )
+int_fast64_t f128M_to_i64_r_minMag( const softfloat128_t *aPtr, bool exact )
 {
 
     return f128_to_i64_r_minMag( *aPtr, exact );
@@ -52,7 +52,7 @@ int_fast64_t f128M_to_i64_r_minMag( const float128_t *aPtr, bool exact )
 
 #else
 
-int_fast64_t f128M_to_i64_r_minMag( const float128_t *aPtr, bool exact )
+int_fast64_t f128M_to_i64_r_minMag( const softfloat128_t *aPtr, bool exact )
 {
     const uint32_t *aWPtr;
     uint32_t uiA96;

--- a/source/f128M_to_ui32.c
+++ b/source/f128M_to_ui32.c
@@ -44,7 +44,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef SOFTFLOAT_FAST_INT64
 
 uint_fast32_t
- f128M_to_ui32( const float128_t *aPtr, uint_fast8_t roundingMode, bool exact )
+ f128M_to_ui32( const softfloat128_t *aPtr, uint_fast8_t roundingMode, bool exact )
 {
 
     return f128_to_ui32( *aPtr, roundingMode, exact );
@@ -54,7 +54,7 @@ uint_fast32_t
 #else
 
 uint_fast32_t
- f128M_to_ui32( const float128_t *aPtr, uint_fast8_t roundingMode, bool exact )
+ f128M_to_ui32( const softfloat128_t *aPtr, uint_fast8_t roundingMode, bool exact )
 {
     const uint32_t *aWPtr;
     uint32_t uiA96;

--- a/source/f128M_to_ui32_r_minMag.c
+++ b/source/f128M_to_ui32_r_minMag.c
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef SOFTFLOAT_FAST_INT64
 
-uint_fast32_t f128M_to_ui32_r_minMag( const float128_t *aPtr, bool exact )
+uint_fast32_t f128M_to_ui32_r_minMag( const softfloat128_t *aPtr, bool exact )
 {
 
     return f128_to_ui32_r_minMag( *aPtr, exact );
@@ -52,7 +52,7 @@ uint_fast32_t f128M_to_ui32_r_minMag( const float128_t *aPtr, bool exact )
 
 #else
 
-uint_fast32_t f128M_to_ui32_r_minMag( const float128_t *aPtr, bool exact )
+uint_fast32_t f128M_to_ui32_r_minMag( const softfloat128_t *aPtr, bool exact )
 {
     const uint32_t *aWPtr;
     uint32_t uiA96;

--- a/source/f128M_to_ui64.c
+++ b/source/f128M_to_ui64.c
@@ -44,7 +44,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef SOFTFLOAT_FAST_INT64
 
 uint_fast64_t
- f128M_to_ui64( const float128_t *aPtr, uint_fast8_t roundingMode, bool exact )
+ f128M_to_ui64( const softfloat128_t *aPtr, uint_fast8_t roundingMode, bool exact )
 {
 
     return f128_to_ui64( *aPtr, roundingMode, exact );
@@ -54,7 +54,7 @@ uint_fast64_t
 #else
 
 uint_fast64_t
- f128M_to_ui64( const float128_t *aPtr, uint_fast8_t roundingMode, bool exact )
+ f128M_to_ui64( const softfloat128_t *aPtr, uint_fast8_t roundingMode, bool exact )
 {
     const uint32_t *aWPtr;
     uint32_t uiA96;

--- a/source/f128M_to_ui64_r_minMag.c
+++ b/source/f128M_to_ui64_r_minMag.c
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef SOFTFLOAT_FAST_INT64
 
-uint_fast64_t f128M_to_ui64_r_minMag( const float128_t *aPtr, bool exact )
+uint_fast64_t f128M_to_ui64_r_minMag( const softfloat128_t *aPtr, bool exact )
 {
 
     return f128_to_ui64_r_minMag( *aPtr, exact );
@@ -52,7 +52,7 @@ uint_fast64_t f128M_to_ui64_r_minMag( const float128_t *aPtr, bool exact )
 
 #else
 
-uint_fast64_t f128M_to_ui64_r_minMag( const float128_t *aPtr, bool exact )
+uint_fast64_t f128M_to_ui64_r_minMag( const softfloat128_t *aPtr, bool exact )
 {
     const uint32_t *aWPtr;
     uint32_t uiA96;

--- a/source/f128_add.c
+++ b/source/f128_add.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float128_t f128_add( float128_t a, float128_t b )
+softfloat128_t f128_add( softfloat128_t a, softfloat128_t b )
 {
     union ui128_f128 uA;
     uint_fast64_t uiA64, uiA0;
@@ -49,7 +49,7 @@ float128_t f128_add( float128_t a, float128_t b )
     uint_fast64_t uiB64, uiB0;
     bool signB;
 #if ! defined INLINE_LEVEL || (INLINE_LEVEL < 2)
-    float128_t
+    softfloat128_t
         (*magsFuncPtr)(
             uint_fast64_t, uint_fast64_t, uint_fast64_t, uint_fast64_t, bool );
 #endif

--- a/source/f128_div.c
+++ b/source/f128_div.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float128_t f128_div( float128_t a, float128_t b )
+softfloat128_t f128_div( softfloat128_t a, softfloat128_t b )
 {
     union ui128_f128 uA;
     uint_fast64_t uiA64, uiA0;

--- a/source/f128_eq.c
+++ b/source/f128_eq.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-bool f128_eq( float128_t a, float128_t b )
+bool f128_eq( softfloat128_t a, softfloat128_t b )
 {
     union ui128_f128 uA;
     uint_fast64_t uiA64, uiA0;

--- a/source/f128_eq_signaling.c
+++ b/source/f128_eq_signaling.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-bool f128_eq_signaling( float128_t a, float128_t b )
+bool f128_eq_signaling( softfloat128_t a, softfloat128_t b )
 {
     union ui128_f128 uA;
     uint_fast64_t uiA64, uiA0;

--- a/source/f128_isSignalingNaN.c
+++ b/source/f128_isSignalingNaN.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-bool f128_isSignalingNaN( float128_t a )
+bool f128_isSignalingNaN( softfloat128_t a )
 {
     union ui128_f128 uA;
 

--- a/source/f128_isnan.c
+++ b/source/f128_isnan.c
@@ -1,7 +1,7 @@
 #include "include/softfloat.h"
 #include "include/internals.h"
 
-bool isNaNF128( const float128_t* f ) {
+bool isNaNF128( const softfloat128_t* f ) {
    const uint32_t* wptr = (const uint32_t*)f;
    return softfloat_isNaNF128M( wptr );
 }

--- a/source/f128_le.c
+++ b/source/f128_le.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-bool f128_le( float128_t a, float128_t b )
+bool f128_le( softfloat128_t a, softfloat128_t b )
 {
     union ui128_f128 uA;
     uint_fast64_t uiA64, uiA0;

--- a/source/f128_le_quiet.c
+++ b/source/f128_le_quiet.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-bool f128_le_quiet( float128_t a, float128_t b )
+bool f128_le_quiet( softfloat128_t a, softfloat128_t b )
 {
     union ui128_f128 uA;
     uint_fast64_t uiA64, uiA0;

--- a/source/f128_lt.c
+++ b/source/f128_lt.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-bool f128_lt( float128_t a, float128_t b )
+bool f128_lt( softfloat128_t a, softfloat128_t b )
 {
     union ui128_f128 uA;
     uint_fast64_t uiA64, uiA0;

--- a/source/f128_lt_quiet.c
+++ b/source/f128_lt_quiet.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-bool f128_lt_quiet( float128_t a, float128_t b )
+bool f128_lt_quiet( softfloat128_t a, softfloat128_t b )
 {
     union ui128_f128 uA;
     uint_fast64_t uiA64, uiA0;

--- a/source/f128_mul.c
+++ b/source/f128_mul.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float128_t f128_mul( float128_t a, float128_t b )
+softfloat128_t f128_mul( softfloat128_t a, softfloat128_t b )
 {
     union ui128_f128 uA;
     uint_fast64_t uiA64, uiA0;

--- a/source/f128_mulAdd.c
+++ b/source/f128_mulAdd.c
@@ -39,7 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float128_t f128_mulAdd( float128_t a, float128_t b, float128_t c )
+softfloat128_t f128_mulAdd( softfloat128_t a, softfloat128_t b, softfloat128_t c )
 {
     union ui128_f128 uA;
     uint_fast64_t uiA64, uiA0;

--- a/source/f128_rem.c
+++ b/source/f128_rem.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float128_t f128_rem( float128_t a, float128_t b )
+softfloat128_t f128_rem( softfloat128_t a, softfloat128_t b )
 {
     union ui128_f128 uA;
     uint_fast64_t uiA64, uiA0;

--- a/source/f128_roundToInt.c
+++ b/source/f128_roundToInt.c
@@ -41,8 +41,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float128_t
- f128_roundToInt( float128_t a, uint_fast8_t roundingMode, bool exact )
+softfloat128_t
+ f128_roundToInt( softfloat128_t a, uint_fast8_t roundingMode, bool exact )
 {
     union ui128_f128 uA;
     uint_fast64_t uiA64, uiA0;

--- a/source/f128_sqrt.c
+++ b/source/f128_sqrt.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float128_t f128_sqrt( float128_t a )
+softfloat128_t f128_sqrt( softfloat128_t a )
 {
     union ui128_f128 uA;
     uint_fast64_t uiA64, uiA0;

--- a/source/f128_sub.c
+++ b/source/f128_sub.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float128_t f128_sub( float128_t a, float128_t b )
+softfloat128_t f128_sub( softfloat128_t a, softfloat128_t b )
 {
     union ui128_f128 uA;
     uint_fast64_t uiA64, uiA0;
@@ -49,7 +49,7 @@ float128_t f128_sub( float128_t a, float128_t b )
     uint_fast64_t uiB64, uiB0;
     bool signB;
 #if ! defined INLINE_LEVEL || (INLINE_LEVEL < 2)
-    float128_t
+    softfloat128_t
         (*magsFuncPtr)(
             uint_fast64_t, uint_fast64_t, uint_fast64_t, uint_fast64_t, bool );
 #endif

--- a/source/f128_to_extF80.c
+++ b/source/f128_to_extF80.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-extFloat80_t f128_to_extF80( float128_t a )
+extFloat80_t f128_to_extF80( softfloat128_t a )
 {
     union ui128_f128 uA;
     uint_fast64_t uiA64, uiA0;

--- a/source/f128_to_f16.c
+++ b/source/f128_to_f16.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float16_t f128_to_f16( float128_t a )
+softfloat16_t f128_to_f16( softfloat128_t a )
 {
     union ui128_f128 uA;
     uint_fast64_t uiA64, uiA0;

--- a/source/f128_to_f32.c
+++ b/source/f128_to_f32.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float32_t f128_to_f32( float128_t a )
+softfloat32_t f128_to_f32( softfloat128_t a )
 {
     union ui128_f128 uA;
     uint_fast64_t uiA64, uiA0;

--- a/source/f128_to_f64.c
+++ b/source/f128_to_f64.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float64_t f128_to_f64( float128_t a )
+softfloat64_t f128_to_f64( softfloat128_t a )
 {
     union ui128_f128 uA;
     uint_fast64_t uiA64, uiA0;

--- a/source/f128_to_i32.c
+++ b/source/f128_to_i32.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-int_fast32_t f128_to_i32( float128_t a, uint_fast8_t roundingMode, bool exact )
+int_fast32_t f128_to_i32( softfloat128_t a, uint_fast8_t roundingMode, bool exact )
 {
     union ui128_f128 uA;
     uint_fast64_t uiA64, uiA0;

--- a/source/f128_to_i32_r_minMag.c
+++ b/source/f128_to_i32_r_minMag.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-int_fast32_t f128_to_i32_r_minMag( float128_t a, bool exact )
+int_fast32_t f128_to_i32_r_minMag( softfloat128_t a, bool exact )
 {
     union ui128_f128 uA;
     uint_fast64_t uiA64, uiA0;

--- a/source/f128_to_i64.c
+++ b/source/f128_to_i64.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-int_fast64_t f128_to_i64( float128_t a, uint_fast8_t roundingMode, bool exact )
+int_fast64_t f128_to_i64( softfloat128_t a, uint_fast8_t roundingMode, bool exact )
 {
     union ui128_f128 uA;
     uint_fast64_t uiA64, uiA0;

--- a/source/f128_to_i64_r_minMag.c
+++ b/source/f128_to_i64_r_minMag.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-int_fast64_t f128_to_i64_r_minMag( float128_t a, bool exact )
+int_fast64_t f128_to_i64_r_minMag( softfloat128_t a, bool exact )
 {
     union ui128_f128 uA;
     uint_fast64_t uiA64, uiA0;

--- a/source/f128_to_ui32.c
+++ b/source/f128_to_ui32.c
@@ -42,7 +42,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "softfloat.h"
 
 uint_fast32_t
- f128_to_ui32( float128_t a, uint_fast8_t roundingMode, bool exact )
+ f128_to_ui32( softfloat128_t a, uint_fast8_t roundingMode, bool exact )
 {
     union ui128_f128 uA;
     uint_fast64_t uiA64, uiA0;

--- a/source/f128_to_ui32_r_minMag.c
+++ b/source/f128_to_ui32_r_minMag.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-uint_fast32_t f128_to_ui32_r_minMag( float128_t a, bool exact )
+uint_fast32_t f128_to_ui32_r_minMag( softfloat128_t a, bool exact )
 {
     union ui128_f128 uA;
     uint_fast64_t uiA64, uiA0;

--- a/source/f128_to_ui64.c
+++ b/source/f128_to_ui64.c
@@ -42,7 +42,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "softfloat.h"
 
 uint_fast64_t
- f128_to_ui64( float128_t a, uint_fast8_t roundingMode, bool exact )
+ f128_to_ui64( softfloat128_t a, uint_fast8_t roundingMode, bool exact )
 {
     union ui128_f128 uA;
     uint_fast64_t uiA64, uiA0;

--- a/source/f128_to_ui64_r_minMag.c
+++ b/source/f128_to_ui64_r_minMag.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-uint_fast64_t f128_to_ui64_r_minMag( float128_t a, bool exact )
+uint_fast64_t f128_to_ui64_r_minMag( softfloat128_t a, bool exact )
 {
     union ui128_f128 uA;
     uint_fast64_t uiA64, uiA0;

--- a/source/f16_add.c
+++ b/source/f16_add.c
@@ -40,14 +40,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float16_t f16_add( float16_t a, float16_t b )
+softfloat16_t f16_add( softfloat16_t a, softfloat16_t b )
 {
     union ui16_f16 uA;
     uint_fast16_t uiA;
     union ui16_f16 uB;
     uint_fast16_t uiB;
 #if ! defined INLINE_LEVEL || (INLINE_LEVEL < 1)
-    float16_t (*magsFuncPtr)( uint_fast16_t, uint_fast16_t );
+    softfloat16_t (*magsFuncPtr)( uint_fast16_t, uint_fast16_t );
 #endif
 
     uA.f = a;

--- a/source/f16_div.c
+++ b/source/f16_div.c
@@ -44,7 +44,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 extern const uint16_t softfloat_approxRecip_1k0s[];
 extern const uint16_t softfloat_approxRecip_1k1s[];
 
-float16_t f16_div( float16_t a, float16_t b )
+softfloat16_t f16_div( softfloat16_t a, softfloat16_t b )
 {
     union ui16_f16 uA;
     uint_fast16_t uiA;

--- a/source/f16_eq.c
+++ b/source/f16_eq.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-bool f16_eq( float16_t a, float16_t b )
+bool f16_eq( softfloat16_t a, softfloat16_t b )
 {
     union ui16_f16 uA;
     uint_fast16_t uiA;

--- a/source/f16_eq_signaling.c
+++ b/source/f16_eq_signaling.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-bool f16_eq_signaling( float16_t a, float16_t b )
+bool f16_eq_signaling( softfloat16_t a, softfloat16_t b )
 {
     union ui16_f16 uA;
     uint_fast16_t uiA;

--- a/source/f16_isSignalingNaN.c
+++ b/source/f16_isSignalingNaN.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-bool f16_isSignalingNaN( float16_t a )
+bool f16_isSignalingNaN( softfloat16_t a )
 {
     union ui16_f16 uA;
 

--- a/source/f16_le.c
+++ b/source/f16_le.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-bool f16_le( float16_t a, float16_t b )
+bool f16_le( softfloat16_t a, softfloat16_t b )
 {
     union ui16_f16 uA;
     uint_fast16_t uiA;

--- a/source/f16_le_quiet.c
+++ b/source/f16_le_quiet.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-bool f16_le_quiet( float16_t a, float16_t b )
+bool f16_le_quiet( softfloat16_t a, softfloat16_t b )
 {
     union ui16_f16 uA;
     uint_fast16_t uiA;

--- a/source/f16_lt.c
+++ b/source/f16_lt.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-bool f16_lt( float16_t a, float16_t b )
+bool f16_lt( softfloat16_t a, softfloat16_t b )
 {
     union ui16_f16 uA;
     uint_fast16_t uiA;

--- a/source/f16_lt_quiet.c
+++ b/source/f16_lt_quiet.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-bool f16_lt_quiet( float16_t a, float16_t b )
+bool f16_lt_quiet( softfloat16_t a, softfloat16_t b )
 {
     union ui16_f16 uA;
     uint_fast16_t uiA;

--- a/source/f16_mul.c
+++ b/source/f16_mul.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float16_t f16_mul( float16_t a, float16_t b )
+softfloat16_t f16_mul( softfloat16_t a, softfloat16_t b )
 {
     union ui16_f16 uA;
     uint_fast16_t uiA;

--- a/source/f16_mulAdd.c
+++ b/source/f16_mulAdd.c
@@ -39,7 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float16_t f16_mulAdd( float16_t a, float16_t b, float16_t c )
+softfloat16_t f16_mulAdd( softfloat16_t a, softfloat16_t b, softfloat16_t c )
 {
     union ui16_f16 uA;
     uint_fast16_t uiA;

--- a/source/f16_rem.c
+++ b/source/f16_rem.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float16_t f16_rem( float16_t a, float16_t b )
+softfloat16_t f16_rem( softfloat16_t a, softfloat16_t b )
 {
     union ui16_f16 uA;
     uint_fast16_t uiA;

--- a/source/f16_roundToInt.c
+++ b/source/f16_roundToInt.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float16_t f16_roundToInt( float16_t a, uint_fast8_t roundingMode, bool exact )
+softfloat16_t f16_roundToInt( softfloat16_t a, uint_fast8_t roundingMode, bool exact )
 {
     union ui16_f16 uA;
     uint_fast16_t uiA;

--- a/source/f16_sqrt.c
+++ b/source/f16_sqrt.c
@@ -44,7 +44,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 extern const uint16_t softfloat_approxRecipSqrt_1k0s[];
 extern const uint16_t softfloat_approxRecipSqrt_1k1s[];
 
-float16_t f16_sqrt( float16_t a )
+softfloat16_t f16_sqrt( softfloat16_t a )
 {
     union ui16_f16 uA;
     uint_fast16_t uiA;

--- a/source/f16_sub.c
+++ b/source/f16_sub.c
@@ -40,14 +40,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float16_t f16_sub( float16_t a, float16_t b )
+softfloat16_t f16_sub( softfloat16_t a, softfloat16_t b )
 {
     union ui16_f16 uA;
     uint_fast16_t uiA;
     union ui16_f16 uB;
     uint_fast16_t uiB;
 #if ! defined INLINE_LEVEL || (INLINE_LEVEL < 1)
-    float16_t (*magsFuncPtr)( uint_fast16_t, uint_fast16_t );
+    softfloat16_t (*magsFuncPtr)( uint_fast16_t, uint_fast16_t );
 #endif
 
     uA.f = a;

--- a/source/f16_to_extF80.c
+++ b/source/f16_to_extF80.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-extFloat80_t f16_to_extF80( float16_t a )
+extFloat80_t f16_to_extF80( softfloat16_t a )
 {
     union ui16_f16 uA;
     uint_fast16_t uiA;

--- a/source/f16_to_extF80M.c
+++ b/source/f16_to_extF80M.c
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef SOFTFLOAT_FAST_INT64
 
-void f16_to_extF80M( float16_t a, extFloat80_t *zPtr )
+void f16_to_extF80M( softfloat16_t a, extFloat80_t *zPtr )
 {
 
     *zPtr = f16_to_extF80( a );
@@ -52,7 +52,7 @@ void f16_to_extF80M( float16_t a, extFloat80_t *zPtr )
 
 #else
 
-void f16_to_extF80M( float16_t a, extFloat80_t *zPtr )
+void f16_to_extF80M( softfloat16_t a, extFloat80_t *zPtr )
 {
     struct extFloat80M *zSPtr;
     union ui16_f16 uA;

--- a/source/f16_to_f128.c
+++ b/source/f16_to_f128.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float128_t f16_to_f128( float16_t a )
+softfloat128_t f16_to_f128( softfloat16_t a )
 {
     union ui16_f16 uA;
     uint_fast16_t uiA;

--- a/source/f16_to_f128M.c
+++ b/source/f16_to_f128M.c
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef SOFTFLOAT_FAST_INT64
 
-void f16_to_f128M( float16_t a, float128_t *zPtr )
+void f16_to_f128M( softfloat16_t a, softfloat128_t *zPtr )
 {
 
     *zPtr = f16_to_f128( a );
@@ -52,7 +52,7 @@ void f16_to_f128M( float16_t a, float128_t *zPtr )
 
 #else
 
-void f16_to_f128M( float16_t a, float128_t *zPtr )
+void f16_to_f128M( softfloat16_t a, softfloat128_t *zPtr )
 {
     uint32_t *zWPtr;
     union ui16_f16 uA;

--- a/source/f16_to_f32.c
+++ b/source/f16_to_f32.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float32_t f16_to_f32( float16_t a )
+softfloat32_t f16_to_f32( softfloat16_t a )
 {
     union ui16_f16 uA;
     uint_fast16_t uiA;

--- a/source/f16_to_f64.c
+++ b/source/f16_to_f64.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float64_t f16_to_f64( float16_t a )
+softfloat64_t f16_to_f64( softfloat16_t a )
 {
     union ui16_f16 uA;
     uint_fast16_t uiA;

--- a/source/f16_to_i32.c
+++ b/source/f16_to_i32.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-int_fast32_t f16_to_i32( float16_t a, uint_fast8_t roundingMode, bool exact )
+int_fast32_t f16_to_i32( softfloat16_t a, uint_fast8_t roundingMode, bool exact )
 {
     union ui16_f16 uA;
     uint_fast16_t uiA;

--- a/source/f16_to_i32_r_minMag.c
+++ b/source/f16_to_i32_r_minMag.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-int_fast32_t f16_to_i32_r_minMag( float16_t a, bool exact )
+int_fast32_t f16_to_i32_r_minMag( softfloat16_t a, bool exact )
 {
     union ui16_f16 uA;
     uint_fast16_t uiA;

--- a/source/f16_to_i64.c
+++ b/source/f16_to_i64.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-int_fast64_t f16_to_i64( float16_t a, uint_fast8_t roundingMode, bool exact )
+int_fast64_t f16_to_i64( softfloat16_t a, uint_fast8_t roundingMode, bool exact )
 {
     union ui16_f16 uA;
     uint_fast16_t uiA;

--- a/source/f16_to_i64_r_minMag.c
+++ b/source/f16_to_i64_r_minMag.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-int_fast64_t f16_to_i64_r_minMag( float16_t a, bool exact )
+int_fast64_t f16_to_i64_r_minMag( softfloat16_t a, bool exact )
 {
     union ui16_f16 uA;
     uint_fast16_t uiA;

--- a/source/f16_to_ui32.c
+++ b/source/f16_to_ui32.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-uint_fast32_t f16_to_ui32( float16_t a, uint_fast8_t roundingMode, bool exact )
+uint_fast32_t f16_to_ui32( softfloat16_t a, uint_fast8_t roundingMode, bool exact )
 {
     union ui16_f16 uA;
     uint_fast16_t uiA;

--- a/source/f16_to_ui32_r_minMag.c
+++ b/source/f16_to_ui32_r_minMag.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-uint_fast32_t f16_to_ui32_r_minMag( float16_t a, bool exact )
+uint_fast32_t f16_to_ui32_r_minMag( softfloat16_t a, bool exact )
 {
     union ui16_f16 uA;
     uint_fast16_t uiA;

--- a/source/f16_to_ui64.c
+++ b/source/f16_to_ui64.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-uint_fast64_t f16_to_ui64( float16_t a, uint_fast8_t roundingMode, bool exact )
+uint_fast64_t f16_to_ui64( softfloat16_t a, uint_fast8_t roundingMode, bool exact )
 {
     union ui16_f16 uA;
     uint_fast16_t uiA;

--- a/source/f16_to_ui64_r_minMag.c
+++ b/source/f16_to_ui64_r_minMag.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-uint_fast64_t f16_to_ui64_r_minMag( float16_t a, bool exact )
+uint_fast64_t f16_to_ui64_r_minMag( softfloat16_t a, bool exact )
 {
     union ui16_f16 uA;
     uint_fast16_t uiA;

--- a/source/f32_add.c
+++ b/source/f32_add.c
@@ -40,14 +40,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float32_t f32_add( float32_t a, float32_t b )
+softfloat32_t f32_add( softfloat32_t a, softfloat32_t b )
 {
     union ui32_f32 uA;
     uint_fast32_t uiA;
     union ui32_f32 uB;
     uint_fast32_t uiB;
 #if ! defined INLINE_LEVEL || (INLINE_LEVEL < 1)
-    float32_t (*magsFuncPtr)( uint_fast32_t, uint_fast32_t );
+    softfloat32_t (*magsFuncPtr)( uint_fast32_t, uint_fast32_t );
 #endif
 
     uA.f = a;

--- a/source/f32_div.c
+++ b/source/f32_div.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float32_t f32_div( float32_t a, float32_t b )
+softfloat32_t f32_div( softfloat32_t a, softfloat32_t b )
 {
     union ui32_f32 uA;
     uint_fast32_t uiA;

--- a/source/f32_eq.c
+++ b/source/f32_eq.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-bool f32_eq( float32_t a, float32_t b )
+bool f32_eq( softfloat32_t a, softfloat32_t b )
 {
     union ui32_f32 uA;
     uint_fast32_t uiA;

--- a/source/f32_eq_signaling.c
+++ b/source/f32_eq_signaling.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-bool f32_eq_signaling( float32_t a, float32_t b )
+bool f32_eq_signaling( softfloat32_t a, softfloat32_t b )
 {
     union ui32_f32 uA;
     uint_fast32_t uiA;

--- a/source/f32_isSignalingNaN.c
+++ b/source/f32_isSignalingNaN.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-bool f32_isSignalingNaN( float32_t a )
+bool f32_isSignalingNaN( softfloat32_t a )
 {
     union ui32_f32 uA;
 

--- a/source/f32_le.c
+++ b/source/f32_le.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-bool f32_le( float32_t a, float32_t b )
+bool f32_le( softfloat32_t a, softfloat32_t b )
 {
     union ui32_f32 uA;
     uint_fast32_t uiA;

--- a/source/f32_le_quiet.c
+++ b/source/f32_le_quiet.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-bool f32_le_quiet( float32_t a, float32_t b )
+bool f32_le_quiet( softfloat32_t a, softfloat32_t b )
 {
     union ui32_f32 uA;
     uint_fast32_t uiA;

--- a/source/f32_lt.c
+++ b/source/f32_lt.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-bool f32_lt( float32_t a, float32_t b )
+bool f32_lt( softfloat32_t a, softfloat32_t b )
 {
     union ui32_f32 uA;
     uint_fast32_t uiA;

--- a/source/f32_lt_quiet.c
+++ b/source/f32_lt_quiet.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-bool f32_lt_quiet( float32_t a, float32_t b )
+bool f32_lt_quiet( softfloat32_t a, softfloat32_t b )
 {
     union ui32_f32 uA;
     uint_fast32_t uiA;

--- a/source/f32_mul.c
+++ b/source/f32_mul.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float32_t f32_mul( float32_t a, float32_t b )
+softfloat32_t f32_mul( softfloat32_t a, softfloat32_t b )
 {
     union ui32_f32 uA;
     uint_fast32_t uiA;

--- a/source/f32_mulAdd.c
+++ b/source/f32_mulAdd.c
@@ -39,7 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float32_t f32_mulAdd( float32_t a, float32_t b, float32_t c )
+softfloat32_t f32_mulAdd( softfloat32_t a, softfloat32_t b, softfloat32_t c )
 {
     union ui32_f32 uA;
     uint_fast32_t uiA;

--- a/source/f32_rem.c
+++ b/source/f32_rem.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float32_t f32_rem( float32_t a, float32_t b )
+softfloat32_t f32_rem( softfloat32_t a, softfloat32_t b )
 {
     union ui32_f32 uA;
     uint_fast32_t uiA;

--- a/source/f32_roundToInt.c
+++ b/source/f32_roundToInt.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float32_t f32_roundToInt( float32_t a, uint_fast8_t roundingMode, bool exact )
+softfloat32_t f32_roundToInt( softfloat32_t a, uint_fast8_t roundingMode, bool exact )
 {
     union ui32_f32 uA;
     uint_fast32_t uiA;

--- a/source/f32_sqrt.c
+++ b/source/f32_sqrt.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float32_t f32_sqrt( float32_t a )
+softfloat32_t f32_sqrt( softfloat32_t a )
 {
     union ui32_f32 uA;
     uint_fast32_t uiA;

--- a/source/f32_sub.c
+++ b/source/f32_sub.c
@@ -40,14 +40,14 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float32_t f32_sub( float32_t a, float32_t b )
+softfloat32_t f32_sub( softfloat32_t a, softfloat32_t b )
 {
     union ui32_f32 uA;
     uint_fast32_t uiA;
     union ui32_f32 uB;
     uint_fast32_t uiB;
 #if ! defined INLINE_LEVEL || (INLINE_LEVEL < 1)
-    float32_t (*magsFuncPtr)( uint_fast32_t, uint_fast32_t );
+    softfloat32_t (*magsFuncPtr)( uint_fast32_t, uint_fast32_t );
 #endif
 
     uA.f = a;

--- a/source/f32_to_extF80.c
+++ b/source/f32_to_extF80.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-extFloat80_t f32_to_extF80( float32_t a )
+extFloat80_t f32_to_extF80( softfloat32_t a )
 {
     union ui32_f32 uA;
     uint_fast32_t uiA;

--- a/source/f32_to_extF80M.c
+++ b/source/f32_to_extF80M.c
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef SOFTFLOAT_FAST_INT64
 
-void f32_to_extF80M( float32_t a, extFloat80_t *zPtr )
+void f32_to_extF80M( softfloat32_t a, extFloat80_t *zPtr )
 {
 
     *zPtr = f32_to_extF80( a );
@@ -52,7 +52,7 @@ void f32_to_extF80M( float32_t a, extFloat80_t *zPtr )
 
 #else
 
-void f32_to_extF80M( float32_t a, extFloat80_t *zPtr )
+void f32_to_extF80M( softfloat32_t a, extFloat80_t *zPtr )
 {
     struct extFloat80M *zSPtr;
     union ui32_f32 uA;

--- a/source/f32_to_f128.c
+++ b/source/f32_to_f128.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float128_t f32_to_f128( float32_t a )
+softfloat128_t f32_to_f128( softfloat32_t a )
 {
     union ui32_f32 uA;
     uint_fast32_t uiA;

--- a/source/f32_to_f128M.c
+++ b/source/f32_to_f128M.c
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef SOFTFLOAT_FAST_INT64
 
-void f32_to_f128M( float32_t a, float128_t *zPtr )
+void f32_to_f128M( softfloat32_t a, softfloat128_t *zPtr )
 {
 
     *zPtr = f32_to_f128( a );
@@ -52,7 +52,7 @@ void f32_to_f128M( float32_t a, float128_t *zPtr )
 
 #else
 
-void f32_to_f128M( float32_t a, float128_t *zPtr )
+void f32_to_f128M( softfloat32_t a, softfloat128_t *zPtr )
 {
     uint32_t *zWPtr;
     union ui32_f32 uA;

--- a/source/f32_to_f16.c
+++ b/source/f32_to_f16.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float16_t f32_to_f16( float32_t a )
+softfloat16_t f32_to_f16( softfloat32_t a )
 {
     union ui32_f32 uA;
     uint_fast32_t uiA;

--- a/source/f32_to_f64.c
+++ b/source/f32_to_f64.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float64_t f32_to_f64( float32_t a )
+softfloat64_t f32_to_f64( softfloat32_t a )
 {
     union ui32_f32 uA;
     uint_fast32_t uiA;

--- a/source/f32_to_i32.c
+++ b/source/f32_to_i32.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-int_fast32_t f32_to_i32( float32_t a, uint_fast8_t roundingMode, bool exact )
+int_fast32_t f32_to_i32( softfloat32_t a, uint_fast8_t roundingMode, bool exact )
 {
     union ui32_f32 uA;
     uint_fast32_t uiA;

--- a/source/f32_to_i32_r_minMag.c
+++ b/source/f32_to_i32_r_minMag.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-int_fast32_t f32_to_i32_r_minMag( float32_t a, bool exact )
+int_fast32_t f32_to_i32_r_minMag( softfloat32_t a, bool exact )
 {
     union ui32_f32 uA;
     uint_fast32_t uiA;

--- a/source/f32_to_i64.c
+++ b/source/f32_to_i64.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-int_fast64_t f32_to_i64( float32_t a, uint_fast8_t roundingMode, bool exact )
+int_fast64_t f32_to_i64( softfloat32_t a, uint_fast8_t roundingMode, bool exact )
 {
     union ui32_f32 uA;
     uint_fast32_t uiA;

--- a/source/f32_to_i64_r_minMag.c
+++ b/source/f32_to_i64_r_minMag.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-int_fast64_t f32_to_i64_r_minMag( float32_t a, bool exact )
+int_fast64_t f32_to_i64_r_minMag( softfloat32_t a, bool exact )
 {
     union ui32_f32 uA;
     uint_fast32_t uiA;

--- a/source/f32_to_ui32.c
+++ b/source/f32_to_ui32.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-uint_fast32_t f32_to_ui32( float32_t a, uint_fast8_t roundingMode, bool exact )
+uint_fast32_t f32_to_ui32( softfloat32_t a, uint_fast8_t roundingMode, bool exact )
 {
     union ui32_f32 uA;
     uint_fast32_t uiA;

--- a/source/f32_to_ui32_r_minMag.c
+++ b/source/f32_to_ui32_r_minMag.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-uint_fast32_t f32_to_ui32_r_minMag( float32_t a, bool exact )
+uint_fast32_t f32_to_ui32_r_minMag( softfloat32_t a, bool exact )
 {
     union ui32_f32 uA;
     uint_fast32_t uiA;

--- a/source/f32_to_ui64.c
+++ b/source/f32_to_ui64.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-uint_fast64_t f32_to_ui64( float32_t a, uint_fast8_t roundingMode, bool exact )
+uint_fast64_t f32_to_ui64( softfloat32_t a, uint_fast8_t roundingMode, bool exact )
 {
     union ui32_f32 uA;
     uint_fast32_t uiA;

--- a/source/f32_to_ui64_r_minMag.c
+++ b/source/f32_to_ui64_r_minMag.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-uint_fast64_t f32_to_ui64_r_minMag( float32_t a, bool exact )
+uint_fast64_t f32_to_ui64_r_minMag( softfloat32_t a, bool exact )
 {
     union ui32_f32 uA;
     uint_fast32_t uiA;

--- a/source/f64_add.c
+++ b/source/f64_add.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float64_t f64_add( float64_t a, float64_t b )
+softfloat64_t f64_add( softfloat64_t a, softfloat64_t b )
 {
     union ui64_f64 uA;
     uint_fast64_t uiA;
@@ -49,7 +49,7 @@ float64_t f64_add( float64_t a, float64_t b )
     uint_fast64_t uiB;
     bool signB;
 #if ! defined INLINE_LEVEL || (INLINE_LEVEL < 2)
-    float64_t (*magsFuncPtr)( uint_fast64_t, uint_fast64_t, bool );
+    softfloat64_t (*magsFuncPtr)( uint_fast64_t, uint_fast64_t, bool );
 #endif
 
     uA.f = a;

--- a/source/f64_div.c
+++ b/source/f64_div.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float64_t f64_div( float64_t a, float64_t b )
+softfloat64_t f64_div( softfloat64_t a, softfloat64_t b )
 {
     union ui64_f64 uA;
     uint_fast64_t uiA;

--- a/source/f64_eq.c
+++ b/source/f64_eq.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-bool f64_eq( float64_t a, float64_t b )
+bool f64_eq( softfloat64_t a, softfloat64_t b )
 {
     union ui64_f64 uA;
     uint_fast64_t uiA;

--- a/source/f64_eq_signaling.c
+++ b/source/f64_eq_signaling.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-bool f64_eq_signaling( float64_t a, float64_t b )
+bool f64_eq_signaling( softfloat64_t a, softfloat64_t b )
 {
     union ui64_f64 uA;
     uint_fast64_t uiA;

--- a/source/f64_isSignalingNaN.c
+++ b/source/f64_isSignalingNaN.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-bool f64_isSignalingNaN( float64_t a )
+bool f64_isSignalingNaN( softfloat64_t a )
 {
     union ui64_f64 uA;
 

--- a/source/f64_le.c
+++ b/source/f64_le.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-bool f64_le( float64_t a, float64_t b )
+bool f64_le( softfloat64_t a, softfloat64_t b )
 {
     union ui64_f64 uA;
     uint_fast64_t uiA;

--- a/source/f64_le_quiet.c
+++ b/source/f64_le_quiet.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-bool f64_le_quiet( float64_t a, float64_t b )
+bool f64_le_quiet( softfloat64_t a, softfloat64_t b )
 {
     union ui64_f64 uA;
     uint_fast64_t uiA;

--- a/source/f64_lt.c
+++ b/source/f64_lt.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-bool f64_lt( float64_t a, float64_t b )
+bool f64_lt( softfloat64_t a, softfloat64_t b )
 {
     union ui64_f64 uA;
     uint_fast64_t uiA;

--- a/source/f64_lt_quiet.c
+++ b/source/f64_lt_quiet.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-bool f64_lt_quiet( float64_t a, float64_t b )
+bool f64_lt_quiet( softfloat64_t a, softfloat64_t b )
 {
     union ui64_f64 uA;
     uint_fast64_t uiA;

--- a/source/f64_mul.c
+++ b/source/f64_mul.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float64_t f64_mul( float64_t a, float64_t b )
+softfloat64_t f64_mul( softfloat64_t a, softfloat64_t b )
 {
     union ui64_f64 uA;
     uint_fast64_t uiA;

--- a/source/f64_mulAdd.c
+++ b/source/f64_mulAdd.c
@@ -39,7 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float64_t f64_mulAdd( float64_t a, float64_t b, float64_t c )
+softfloat64_t f64_mulAdd( softfloat64_t a, softfloat64_t b, softfloat64_t c )
 {
     union ui64_f64 uA;
     uint_fast64_t uiA;

--- a/source/f64_rem.c
+++ b/source/f64_rem.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float64_t f64_rem( float64_t a, float64_t b )
+softfloat64_t f64_rem( softfloat64_t a, softfloat64_t b )
 {
     union ui64_f64 uA;
     uint_fast64_t uiA;

--- a/source/f64_roundToInt.c
+++ b/source/f64_roundToInt.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float64_t f64_roundToInt( float64_t a, uint_fast8_t roundingMode, bool exact )
+softfloat64_t f64_roundToInt( softfloat64_t a, uint_fast8_t roundingMode, bool exact )
 {
     union ui64_f64 uA;
     uint_fast64_t uiA;

--- a/source/f64_sqrt.c
+++ b/source/f64_sqrt.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float64_t f64_sqrt( float64_t a )
+softfloat64_t f64_sqrt( softfloat64_t a )
 {
     union ui64_f64 uA;
     uint_fast64_t uiA;

--- a/source/f64_sub.c
+++ b/source/f64_sub.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float64_t f64_sub( float64_t a, float64_t b )
+softfloat64_t f64_sub( softfloat64_t a, softfloat64_t b )
 {
     union ui64_f64 uA;
     uint_fast64_t uiA;
@@ -49,7 +49,7 @@ float64_t f64_sub( float64_t a, float64_t b )
     uint_fast64_t uiB;
     bool signB;
 #if ! defined INLINE_LEVEL || (INLINE_LEVEL < 2)
-    float64_t (*magsFuncPtr)( uint_fast64_t, uint_fast64_t, bool );
+    softfloat64_t (*magsFuncPtr)( uint_fast64_t, uint_fast64_t, bool );
 #endif
 
     uA.f = a;

--- a/source/f64_to_extF80.c
+++ b/source/f64_to_extF80.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-extFloat80_t f64_to_extF80( float64_t a )
+extFloat80_t f64_to_extF80( softfloat64_t a )
 {
     union ui64_f64 uA;
     uint_fast64_t uiA;

--- a/source/f64_to_extF80M.c
+++ b/source/f64_to_extF80M.c
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef SOFTFLOAT_FAST_INT64
 
-void f64_to_extF80M( float64_t a, extFloat80_t *zPtr )
+void f64_to_extF80M( softfloat64_t a, extFloat80_t *zPtr )
 {
 
     *zPtr = f64_to_extF80( a );
@@ -52,7 +52,7 @@ void f64_to_extF80M( float64_t a, extFloat80_t *zPtr )
 
 #else
 
-void f64_to_extF80M( float64_t a, extFloat80_t *zPtr )
+void f64_to_extF80M( softfloat64_t a, extFloat80_t *zPtr )
 {
     struct extFloat80M *zSPtr;
     union ui64_f64 uA;

--- a/source/f64_to_f128.c
+++ b/source/f64_to_f128.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float128_t f64_to_f128( float64_t a )
+softfloat128_t f64_to_f128( softfloat64_t a )
 {
     union ui64_f64 uA;
     uint_fast64_t uiA;

--- a/source/f64_to_f128M.c
+++ b/source/f64_to_f128M.c
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef SOFTFLOAT_FAST_INT64
 
-void f64_to_f128M( float64_t a, float128_t *zPtr )
+void f64_to_f128M( softfloat64_t a, softfloat128_t *zPtr )
 {
 
     *zPtr = f64_to_f128( a );
@@ -52,7 +52,7 @@ void f64_to_f128M( float64_t a, float128_t *zPtr )
 
 #else
 
-void f64_to_f128M( float64_t a, float128_t *zPtr )
+void f64_to_f128M( softfloat64_t a, softfloat128_t *zPtr )
 {
     uint32_t *zWPtr;
     union ui64_f64 uA;

--- a/source/f64_to_f16.c
+++ b/source/f64_to_f16.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float16_t f64_to_f16( float64_t a )
+softfloat16_t f64_to_f16( softfloat64_t a )
 {
     union ui64_f64 uA;
     uint_fast64_t uiA;

--- a/source/f64_to_f32.c
+++ b/source/f64_to_f32.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float32_t f64_to_f32( float64_t a )
+softfloat32_t f64_to_f32( softfloat64_t a )
 {
     union ui64_f64 uA;
     uint_fast64_t uiA;

--- a/source/f64_to_i32.c
+++ b/source/f64_to_i32.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-int_fast32_t f64_to_i32( float64_t a, uint_fast8_t roundingMode, bool exact )
+int_fast32_t f64_to_i32( softfloat64_t a, uint_fast8_t roundingMode, bool exact )
 {
     union ui64_f64 uA;
     uint_fast64_t uiA;

--- a/source/f64_to_i32_r_minMag.c
+++ b/source/f64_to_i32_r_minMag.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-int_fast32_t f64_to_i32_r_minMag( float64_t a, bool exact )
+int_fast32_t f64_to_i32_r_minMag( softfloat64_t a, bool exact )
 {
     union ui64_f64 uA;
     uint_fast64_t uiA;

--- a/source/f64_to_i64.c
+++ b/source/f64_to_i64.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-int_fast64_t f64_to_i64( float64_t a, uint_fast8_t roundingMode, bool exact )
+int_fast64_t f64_to_i64( softfloat64_t a, uint_fast8_t roundingMode, bool exact )
 {
     union ui64_f64 uA;
     uint_fast64_t uiA;

--- a/source/f64_to_i64_r_minMag.c
+++ b/source/f64_to_i64_r_minMag.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-int_fast64_t f64_to_i64_r_minMag( float64_t a, bool exact )
+int_fast64_t f64_to_i64_r_minMag( softfloat64_t a, bool exact )
 {
     union ui64_f64 uA;
     uint_fast64_t uiA;

--- a/source/f64_to_ui32.c
+++ b/source/f64_to_ui32.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-uint_fast32_t f64_to_ui32( float64_t a, uint_fast8_t roundingMode, bool exact )
+uint_fast32_t f64_to_ui32( softfloat64_t a, uint_fast8_t roundingMode, bool exact )
 {
     union ui64_f64 uA;
     uint_fast64_t uiA;

--- a/source/f64_to_ui32_r_minMag.c
+++ b/source/f64_to_ui32_r_minMag.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-uint_fast32_t f64_to_ui32_r_minMag( float64_t a, bool exact )
+uint_fast32_t f64_to_ui32_r_minMag( softfloat64_t a, bool exact )
 {
     union ui64_f64 uA;
     uint_fast64_t uiA;

--- a/source/f64_to_ui64.c
+++ b/source/f64_to_ui64.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-uint_fast64_t f64_to_ui64( float64_t a, uint_fast8_t roundingMode, bool exact )
+uint_fast64_t f64_to_ui64( softfloat64_t a, uint_fast8_t roundingMode, bool exact )
 {
     union ui64_f64 uA;
     uint_fast64_t uiA;

--- a/source/f64_to_ui64_r_minMag.c
+++ b/source/f64_to_ui64_r_minMag.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-uint_fast64_t f64_to_ui64_r_minMag( float64_t a, bool exact )
+uint_fast64_t f64_to_ui64_r_minMag( softfloat64_t a, bool exact )
 {
     union ui64_f64 uA;
     uint_fast64_t uiA;

--- a/source/i32_to_f128.c
+++ b/source/i32_to_f128.c
@@ -39,7 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float128_t i32_to_f128( int32_t a )
+softfloat128_t i32_to_f128( int32_t a )
 {
     uint_fast64_t uiZ64;
     bool sign;

--- a/source/i32_to_f128M.c
+++ b/source/i32_to_f128M.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef SOFTFLOAT_FAST_INT64
 
-void i32_to_f128M( int32_t a, float128_t *zPtr )
+void i32_to_f128M( int32_t a, softfloat128_t *zPtr )
 {
 
     *zPtr = i32_to_f128( a );
@@ -50,7 +50,7 @@ void i32_to_f128M( int32_t a, float128_t *zPtr )
 
 #else
 
-void i32_to_f128M( int32_t a, float128_t *zPtr )
+void i32_to_f128M( int32_t a, softfloat128_t *zPtr )
 {
     uint32_t *zWPtr;
     uint32_t uiZ96, uiZ64;

--- a/source/i32_to_f16.c
+++ b/source/i32_to_f16.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float16_t i32_to_f16( int32_t a )
+softfloat16_t i32_to_f16( int32_t a )
 {
     bool sign;
     uint_fast32_t absA;

--- a/source/i32_to_f32.c
+++ b/source/i32_to_f32.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float32_t i32_to_f32( int32_t a )
+softfloat32_t i32_to_f32( int32_t a )
 {
     bool sign;
     union ui32_f32 uZ;

--- a/source/i32_to_f64.c
+++ b/source/i32_to_f64.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float64_t i32_to_f64( int32_t a )
+softfloat64_t i32_to_f64( int32_t a )
 {
     uint_fast64_t uiZ;
     bool sign;

--- a/source/i64_to_f128.c
+++ b/source/i64_to_f128.c
@@ -39,7 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float128_t i64_to_f128( int64_t a )
+softfloat128_t i64_to_f128( int64_t a )
 {
     uint_fast64_t uiZ64, uiZ0;
     bool sign;

--- a/source/i64_to_f128M.c
+++ b/source/i64_to_f128M.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef SOFTFLOAT_FAST_INT64
 
-void i64_to_f128M( int64_t a, float128_t *zPtr )
+void i64_to_f128M( int64_t a, softfloat128_t *zPtr )
 {
 
     *zPtr = i64_to_f128( a );
@@ -50,7 +50,7 @@ void i64_to_f128M( int64_t a, float128_t *zPtr )
 
 #else
 
-void i64_to_f128M( int64_t a, float128_t *zPtr )
+void i64_to_f128M( int64_t a, softfloat128_t *zPtr )
 {
     uint32_t *zWPtr;
     uint32_t uiZ96, uiZ64;

--- a/source/i64_to_f16.c
+++ b/source/i64_to_f16.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float16_t i64_to_f16( int64_t a )
+softfloat16_t i64_to_f16( int64_t a )
 {
     bool sign;
     uint_fast64_t absA;

--- a/source/i64_to_f32.c
+++ b/source/i64_to_f32.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float32_t i64_to_f32( int64_t a )
+softfloat32_t i64_to_f32( int64_t a )
 {
     bool sign;
     uint_fast64_t absA;

--- a/source/i64_to_f64.c
+++ b/source/i64_to_f64.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float64_t i64_to_f64( int64_t a )
+softfloat64_t i64_to_f64( int64_t a )
 {
     bool sign;
     union ui64_f64 uZ;

--- a/source/include/internals.h
+++ b/source/include/internals.h
@@ -42,13 +42,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "primitives.h"
 #include "softfloat_types.h"
 
-union ui16_f16 { uint16_t ui; float16_t f; };
-union ui32_f32 { uint32_t ui; float32_t f; };
-union ui64_f64 { uint64_t ui; float64_t f; };
+union ui16_f16 { uint16_t ui; softfloat16_t f; };
+union ui32_f32 { uint32_t ui; softfloat32_t f; };
+union ui64_f64 { uint64_t ui; softfloat64_t f; };
 
 #ifdef SOFTFLOAT_FAST_INT64
 union extF80M_extF80 { struct extFloat80M fM; extFloat80_t f; };
-union ui128_f128 { struct uint128 ui; float128_t f; };
+union ui128_f128 { struct uint128 ui; softfloat128_t f; };
 #endif
 
 enum {
@@ -90,12 +90,12 @@ int_fast64_t softfloat_roundMToI64( bool, uint32_t *, uint_fast8_t, bool );
 struct exp8_sig16 { int_fast8_t exp; uint_fast16_t sig; };
 struct exp8_sig16 softfloat_normSubnormalF16Sig( uint_fast16_t );
 
-float16_t softfloat_roundPackToF16( bool, int_fast16_t, uint_fast16_t );
-float16_t softfloat_normRoundPackToF16( bool, int_fast16_t, uint_fast16_t );
+softfloat16_t softfloat_roundPackToF16( bool, int_fast16_t, uint_fast16_t );
+softfloat16_t softfloat_normRoundPackToF16( bool, int_fast16_t, uint_fast16_t );
 
-float16_t softfloat_addMagsF16( uint_fast16_t, uint_fast16_t );
-float16_t softfloat_subMagsF16( uint_fast16_t, uint_fast16_t );
-float16_t
+softfloat16_t softfloat_addMagsF16( uint_fast16_t, uint_fast16_t );
+softfloat16_t softfloat_subMagsF16( uint_fast16_t, uint_fast16_t );
+softfloat16_t
  softfloat_mulAddF16(
      uint_fast16_t, uint_fast16_t, uint_fast16_t, uint_fast8_t );
 
@@ -111,12 +111,12 @@ float16_t
 struct exp16_sig32 { int_fast16_t exp; uint_fast32_t sig; };
 struct exp16_sig32 softfloat_normSubnormalF32Sig( uint_fast32_t );
 
-float32_t softfloat_roundPackToF32( bool, int_fast16_t, uint_fast32_t );
-float32_t softfloat_normRoundPackToF32( bool, int_fast16_t, uint_fast32_t );
+softfloat32_t softfloat_roundPackToF32( bool, int_fast16_t, uint_fast32_t );
+softfloat32_t softfloat_normRoundPackToF32( bool, int_fast16_t, uint_fast32_t );
 
-float32_t softfloat_addMagsF32( uint_fast32_t, uint_fast32_t );
-float32_t softfloat_subMagsF32( uint_fast32_t, uint_fast32_t );
-float32_t
+softfloat32_t softfloat_addMagsF32( uint_fast32_t, uint_fast32_t );
+softfloat32_t softfloat_subMagsF32( uint_fast32_t, uint_fast32_t );
+softfloat32_t
  softfloat_mulAddF32(
      uint_fast32_t, uint_fast32_t, uint_fast32_t, uint_fast8_t );
 
@@ -132,12 +132,12 @@ float32_t
 struct exp16_sig64 { int_fast16_t exp; uint_fast64_t sig; };
 struct exp16_sig64 softfloat_normSubnormalF64Sig( uint_fast64_t );
 
-float64_t softfloat_roundPackToF64( bool, int_fast16_t, uint_fast64_t );
-float64_t softfloat_normRoundPackToF64( bool, int_fast16_t, uint_fast64_t );
+softfloat64_t softfloat_roundPackToF64( bool, int_fast16_t, uint_fast64_t );
+softfloat64_t softfloat_normRoundPackToF64( bool, int_fast16_t, uint_fast64_t );
 
-float64_t softfloat_addMagsF64( uint_fast64_t, uint_fast64_t, bool );
-float64_t softfloat_subMagsF64( uint_fast64_t, uint_fast64_t, bool );
-float64_t
+softfloat64_t softfloat_addMagsF64( uint_fast64_t, uint_fast64_t, bool );
+softfloat64_t softfloat_subMagsF64( uint_fast64_t, uint_fast64_t, bool );
+softfloat64_t
  softfloat_mulAddF64(
      uint_fast64_t, uint_fast64_t, uint_fast64_t, uint_fast8_t );
 
@@ -184,20 +184,20 @@ struct exp32_sig128 { int_fast32_t exp; struct uint128 sig; };
 struct exp32_sig128
  softfloat_normSubnormalF128Sig( uint_fast64_t, uint_fast64_t );
 
-float128_t
+softfloat128_t
  softfloat_roundPackToF128(
      bool, int_fast32_t, uint_fast64_t, uint_fast64_t, uint_fast64_t );
-float128_t
+softfloat128_t
  softfloat_normRoundPackToF128(
      bool, int_fast32_t, uint_fast64_t, uint_fast64_t );
 
-float128_t
+softfloat128_t
  softfloat_addMagsF128(
      uint_fast64_t, uint_fast64_t, uint_fast64_t, uint_fast64_t, bool );
-float128_t
+softfloat128_t
  softfloat_subMagsF128(
      uint_fast64_t, uint_fast64_t, uint_fast64_t, uint_fast64_t, bool );
-float128_t
+softfloat128_t
  softfloat_mulAddF128(
      uint_fast64_t,
      uint_fast64_t,

--- a/source/include/softfloat.h
+++ b/source/include/softfloat.h
@@ -97,147 +97,147 @@ void softfloat_raiseFlags( uint_fast8_t );
 /*----------------------------------------------------------------------------
 | Integer-to-floating-point conversion routines.
 *----------------------------------------------------------------------------*/
-float16_t ui32_to_f16( uint32_t );
-float32_t ui32_to_f32( uint32_t );
-float64_t ui32_to_f64( uint32_t );
+softfloat16_t ui32_to_f16( uint32_t );
+softfloat32_t ui32_to_f32( uint32_t );
+softfloat64_t ui32_to_f64( uint32_t );
 #ifdef SOFTFLOAT_FAST_INT64
 extFloat80_t ui32_to_extF80( uint32_t );
-float128_t ui32_to_f128( uint32_t );
+softfloat128_t ui32_to_f128( uint32_t );
 #endif
 void ui32_to_extF80M( uint32_t, extFloat80_t * );
-void ui32_to_f128M( uint32_t, float128_t * );
-float16_t ui64_to_f16( uint64_t );
-float32_t ui64_to_f32( uint64_t );
-float64_t ui64_to_f64( uint64_t );
+void ui32_to_f128M( uint32_t, softfloat128_t * );
+softfloat16_t ui64_to_f16( uint64_t );
+softfloat32_t ui64_to_f32( uint64_t );
+softfloat64_t ui64_to_f64( uint64_t );
 #ifdef SOFTFLOAT_FAST_INT64
 extFloat80_t ui64_to_extF80( uint64_t );
-float128_t ui64_to_f128( uint64_t );
+softfloat128_t ui64_to_f128( uint64_t );
 #endif
 void ui64_to_extF80M( uint64_t, extFloat80_t * );
-void ui64_to_f128M( uint64_t, float128_t * );
-float16_t i32_to_f16( int32_t );
-float32_t i32_to_f32( int32_t );
-float64_t i32_to_f64( int32_t );
+void ui64_to_f128M( uint64_t, softfloat128_t * );
+softfloat16_t i32_to_f16( int32_t );
+softfloat32_t i32_to_f32( int32_t );
+softfloat64_t i32_to_f64( int32_t );
 #ifdef SOFTFLOAT_FAST_INT64
 extFloat80_t i32_to_extF80( int32_t );
-float128_t i32_to_f128( int32_t );
+softfloat128_t i32_to_f128( int32_t );
 #endif
 void i32_to_extF80M( int32_t, extFloat80_t * );
-void i32_to_f128M( int32_t, float128_t * );
-float16_t i64_to_f16( int64_t );
-float32_t i64_to_f32( int64_t );
-float64_t i64_to_f64( int64_t );
+void i32_to_f128M( int32_t, softfloat128_t * );
+softfloat16_t i64_to_f16( int64_t );
+softfloat32_t i64_to_f32( int64_t );
+softfloat64_t i64_to_f64( int64_t );
 #ifdef SOFTFLOAT_FAST_INT64
 extFloat80_t i64_to_extF80( int64_t );
-float128_t i64_to_f128( int64_t );
+softfloat128_t i64_to_f128( int64_t );
 #endif
 void i64_to_extF80M( int64_t, extFloat80_t * );
-void i64_to_f128M( int64_t, float128_t * );
+void i64_to_f128M( int64_t, softfloat128_t * );
 
 /*----------------------------------------------------------------------------
 | 16-bit (half-precision) floating-point operations.
 *----------------------------------------------------------------------------*/
-uint_fast32_t f16_to_ui32( float16_t, uint_fast8_t, bool );
-uint_fast64_t f16_to_ui64( float16_t, uint_fast8_t, bool );
-int_fast32_t f16_to_i32( float16_t, uint_fast8_t, bool );
-int_fast64_t f16_to_i64( float16_t, uint_fast8_t, bool );
-uint_fast32_t f16_to_ui32_r_minMag( float16_t, bool );
-uint_fast64_t f16_to_ui64_r_minMag( float16_t, bool );
-int_fast32_t f16_to_i32_r_minMag( float16_t, bool );
-int_fast64_t f16_to_i64_r_minMag( float16_t, bool );
-float32_t f16_to_f32( float16_t );
-float64_t f16_to_f64( float16_t );
+uint_fast32_t f16_to_ui32( softfloat16_t, uint_fast8_t, bool );
+uint_fast64_t f16_to_ui64( softfloat16_t, uint_fast8_t, bool );
+int_fast32_t f16_to_i32( softfloat16_t, uint_fast8_t, bool );
+int_fast64_t f16_to_i64( softfloat16_t, uint_fast8_t, bool );
+uint_fast32_t f16_to_ui32_r_minMag( softfloat16_t, bool );
+uint_fast64_t f16_to_ui64_r_minMag( softfloat16_t, bool );
+int_fast32_t f16_to_i32_r_minMag( softfloat16_t, bool );
+int_fast64_t f16_to_i64_r_minMag( softfloat16_t, bool );
+softfloat32_t f16_to_f32( softfloat16_t );
+softfloat64_t f16_to_f64( softfloat16_t );
 #ifdef SOFTFLOAT_FAST_INT64
-extFloat80_t f16_to_extF80( float16_t );
-float128_t f16_to_f128( float16_t );
+extFloat80_t f16_to_extF80( softfloat16_t );
+softfloat128_t f16_to_f128( softfloat16_t );
 #endif
-void f16_to_extF80M( float16_t, extFloat80_t * );
-void f16_to_f128M( float16_t, float128_t * );
-float16_t f16_roundToInt( float16_t, uint_fast8_t, bool );
-float16_t f16_add( float16_t, float16_t );
-float16_t f16_sub( float16_t, float16_t );
-float16_t f16_mul( float16_t, float16_t );
-float16_t f16_mulAdd( float16_t, float16_t, float16_t );
-float16_t f16_div( float16_t, float16_t );
-float16_t f16_rem( float16_t, float16_t );
-float16_t f16_sqrt( float16_t );
-bool f16_eq( float16_t, float16_t );
-bool f16_le( float16_t, float16_t );
-bool f16_lt( float16_t, float16_t );
-bool f16_eq_signaling( float16_t, float16_t );
-bool f16_le_quiet( float16_t, float16_t );
-bool f16_lt_quiet( float16_t, float16_t );
-bool f16_isSignalingNaN( float16_t );
+void f16_to_extF80M( softfloat16_t, extFloat80_t * );
+void f16_to_f128M( softfloat16_t, softfloat128_t * );
+softfloat16_t f16_roundToInt( softfloat16_t, uint_fast8_t, bool );
+softfloat16_t f16_add( softfloat16_t, softfloat16_t );
+softfloat16_t f16_sub( softfloat16_t, softfloat16_t );
+softfloat16_t f16_mul( softfloat16_t, softfloat16_t );
+softfloat16_t f16_mulAdd( softfloat16_t, softfloat16_t, softfloat16_t );
+softfloat16_t f16_div( softfloat16_t, softfloat16_t );
+softfloat16_t f16_rem( softfloat16_t, softfloat16_t );
+softfloat16_t f16_sqrt( softfloat16_t );
+bool f16_eq( softfloat16_t, softfloat16_t );
+bool f16_le( softfloat16_t, softfloat16_t );
+bool f16_lt( softfloat16_t, softfloat16_t );
+bool f16_eq_signaling( softfloat16_t, softfloat16_t );
+bool f16_le_quiet( softfloat16_t, softfloat16_t );
+bool f16_lt_quiet( softfloat16_t, softfloat16_t );
+bool f16_isSignalingNaN( softfloat16_t );
 
 /*----------------------------------------------------------------------------
 | 32-bit (single-precision) floating-point operations.
 *----------------------------------------------------------------------------*/
-uint_fast32_t f32_to_ui32( float32_t, uint_fast8_t, bool );
-uint_fast64_t f32_to_ui64( float32_t, uint_fast8_t, bool );
-int_fast32_t f32_to_i32( float32_t, uint_fast8_t, bool );
-int_fast64_t f32_to_i64( float32_t, uint_fast8_t, bool );
-uint_fast32_t f32_to_ui32_r_minMag( float32_t, bool );
-uint_fast64_t f32_to_ui64_r_minMag( float32_t, bool );
-int_fast32_t f32_to_i32_r_minMag( float32_t, bool );
-int_fast64_t f32_to_i64_r_minMag( float32_t, bool );
-float16_t f32_to_f16( float32_t );
-float64_t f32_to_f64( float32_t );
+uint_fast32_t f32_to_ui32( softfloat32_t, uint_fast8_t, bool );
+uint_fast64_t f32_to_ui64( softfloat32_t, uint_fast8_t, bool );
+int_fast32_t f32_to_i32( softfloat32_t, uint_fast8_t, bool );
+int_fast64_t f32_to_i64( softfloat32_t, uint_fast8_t, bool );
+uint_fast32_t f32_to_ui32_r_minMag( softfloat32_t, bool );
+uint_fast64_t f32_to_ui64_r_minMag( softfloat32_t, bool );
+int_fast32_t f32_to_i32_r_minMag( softfloat32_t, bool );
+int_fast64_t f32_to_i64_r_minMag( softfloat32_t, bool );
+softfloat16_t f32_to_f16( softfloat32_t );
+softfloat64_t f32_to_f64( softfloat32_t );
 #ifdef SOFTFLOAT_FAST_INT64
-extFloat80_t f32_to_extF80( float32_t );
-float128_t f32_to_f128( float32_t );
+extFloat80_t f32_to_extF80( softfloat32_t );
+softfloat128_t f32_to_f128( softfloat32_t );
 #endif
-void f32_to_extF80M( float32_t, extFloat80_t * );
-void f32_to_f128M( float32_t, float128_t * );
-float32_t f32_roundToInt( float32_t, uint_fast8_t, bool );
-float32_t f32_add( float32_t, float32_t );
-float32_t f32_sub( float32_t, float32_t );
-float32_t f32_mul( float32_t, float32_t );
-float32_t f32_mulAdd( float32_t, float32_t, float32_t );
-float32_t f32_div( float32_t, float32_t );
-float32_t f32_rem( float32_t, float32_t );
-float32_t f32_sqrt( float32_t );
-bool f32_eq( float32_t, float32_t );
-bool f32_le( float32_t, float32_t );
-bool f32_lt( float32_t, float32_t );
-bool f32_eq_signaling( float32_t, float32_t );
-bool f32_le_quiet( float32_t, float32_t );
-bool f32_lt_quiet( float32_t, float32_t );
-bool f32_isSignalingNaN( float32_t );
+void f32_to_extF80M( softfloat32_t, extFloat80_t * );
+void f32_to_f128M( softfloat32_t, softfloat128_t * );
+softfloat32_t f32_roundToInt( softfloat32_t, uint_fast8_t, bool );
+softfloat32_t f32_add( softfloat32_t, softfloat32_t );
+softfloat32_t f32_sub( softfloat32_t, softfloat32_t );
+softfloat32_t f32_mul( softfloat32_t, softfloat32_t );
+softfloat32_t f32_mulAdd( softfloat32_t, softfloat32_t, softfloat32_t );
+softfloat32_t f32_div( softfloat32_t, softfloat32_t );
+softfloat32_t f32_rem( softfloat32_t, softfloat32_t );
+softfloat32_t f32_sqrt( softfloat32_t );
+bool f32_eq( softfloat32_t, softfloat32_t );
+bool f32_le( softfloat32_t, softfloat32_t );
+bool f32_lt( softfloat32_t, softfloat32_t );
+bool f32_eq_signaling( softfloat32_t, softfloat32_t );
+bool f32_le_quiet( softfloat32_t, softfloat32_t );
+bool f32_lt_quiet( softfloat32_t, softfloat32_t );
+bool f32_isSignalingNaN( softfloat32_t );
 
 /*----------------------------------------------------------------------------
 | 64-bit (double-precision) floating-point operations.
 *----------------------------------------------------------------------------*/
-uint_fast32_t f64_to_ui32( float64_t, uint_fast8_t, bool );
-uint_fast64_t f64_to_ui64( float64_t, uint_fast8_t, bool );
-int_fast32_t f64_to_i32( float64_t, uint_fast8_t, bool );
-int_fast64_t f64_to_i64( float64_t, uint_fast8_t, bool );
-uint_fast32_t f64_to_ui32_r_minMag( float64_t, bool );
-uint_fast64_t f64_to_ui64_r_minMag( float64_t, bool );
-int_fast32_t f64_to_i32_r_minMag( float64_t, bool );
-int_fast64_t f64_to_i64_r_minMag( float64_t, bool );
-float16_t f64_to_f16( float64_t );
-float32_t f64_to_f32( float64_t );
+uint_fast32_t f64_to_ui32( softfloat64_t, uint_fast8_t, bool );
+uint_fast64_t f64_to_ui64( softfloat64_t, uint_fast8_t, bool );
+int_fast32_t f64_to_i32( softfloat64_t, uint_fast8_t, bool );
+int_fast64_t f64_to_i64( softfloat64_t, uint_fast8_t, bool );
+uint_fast32_t f64_to_ui32_r_minMag( softfloat64_t, bool );
+uint_fast64_t f64_to_ui64_r_minMag( softfloat64_t, bool );
+int_fast32_t f64_to_i32_r_minMag( softfloat64_t, bool );
+int_fast64_t f64_to_i64_r_minMag( softfloat64_t, bool );
+softfloat16_t f64_to_f16( softfloat64_t );
+softfloat32_t f64_to_f32( softfloat64_t );
 #ifdef SOFTFLOAT_FAST_INT64
-extFloat80_t f64_to_extF80( float64_t );
-float128_t f64_to_f128( float64_t );
+extFloat80_t f64_to_extF80( softfloat64_t );
+softfloat128_t f64_to_f128( softfloat64_t );
 #endif
-void f64_to_extF80M( float64_t, extFloat80_t * );
-void f64_to_f128M( float64_t, float128_t * );
-float64_t f64_roundToInt( float64_t, uint_fast8_t, bool );
-float64_t f64_add( float64_t, float64_t );
-float64_t f64_sub( float64_t, float64_t );
-float64_t f64_mul( float64_t, float64_t );
-float64_t f64_mulAdd( float64_t, float64_t, float64_t );
-float64_t f64_div( float64_t, float64_t );
-float64_t f64_rem( float64_t, float64_t );
-float64_t f64_sqrt( float64_t );
-bool f64_eq( float64_t, float64_t );
-bool f64_le( float64_t, float64_t );
-bool f64_lt( float64_t, float64_t );
-bool f64_eq_signaling( float64_t, float64_t );
-bool f64_le_quiet( float64_t, float64_t );
-bool f64_lt_quiet( float64_t, float64_t );
-bool f64_isSignalingNaN( float64_t );
+void f64_to_extF80M( softfloat64_t, extFloat80_t * );
+void f64_to_f128M( softfloat64_t, softfloat128_t * );
+softfloat64_t f64_roundToInt( softfloat64_t, uint_fast8_t, bool );
+softfloat64_t f64_add( softfloat64_t, softfloat64_t );
+softfloat64_t f64_sub( softfloat64_t, softfloat64_t );
+softfloat64_t f64_mul( softfloat64_t, softfloat64_t );
+softfloat64_t f64_mulAdd( softfloat64_t, softfloat64_t, softfloat64_t );
+softfloat64_t f64_div( softfloat64_t, softfloat64_t );
+softfloat64_t f64_rem( softfloat64_t, softfloat64_t );
+softfloat64_t f64_sqrt( softfloat64_t );
+bool f64_eq( softfloat64_t, softfloat64_t );
+bool f64_le( softfloat64_t, softfloat64_t );
+bool f64_lt( softfloat64_t, softfloat64_t );
+bool f64_eq_signaling( softfloat64_t, softfloat64_t );
+bool f64_le_quiet( softfloat64_t, softfloat64_t );
+bool f64_lt_quiet( softfloat64_t, softfloat64_t );
+bool f64_isSignalingNaN( softfloat64_t );
 
 /*----------------------------------------------------------------------------
 | Rounding precision for 80-bit extended double-precision floating-point.
@@ -257,10 +257,10 @@ uint_fast32_t extF80_to_ui32_r_minMag( extFloat80_t, bool );
 uint_fast64_t extF80_to_ui64_r_minMag( extFloat80_t, bool );
 int_fast32_t extF80_to_i32_r_minMag( extFloat80_t, bool );
 int_fast64_t extF80_to_i64_r_minMag( extFloat80_t, bool );
-float16_t extF80_to_f16( extFloat80_t );
-float32_t extF80_to_f32( extFloat80_t );
-float64_t extF80_to_f64( extFloat80_t );
-float128_t extF80_to_f128( extFloat80_t );
+softfloat16_t extF80_to_f16( extFloat80_t );
+softfloat32_t extF80_to_f32( extFloat80_t );
+softfloat64_t extF80_to_f64( extFloat80_t );
+softfloat128_t extF80_to_f128( extFloat80_t );
 extFloat80_t extF80_roundToInt( extFloat80_t, uint_fast8_t, bool );
 extFloat80_t extF80_add( extFloat80_t, extFloat80_t );
 extFloat80_t extF80_sub( extFloat80_t, extFloat80_t );
@@ -284,10 +284,10 @@ uint_fast32_t extF80M_to_ui32_r_minMag( const extFloat80_t *, bool );
 uint_fast64_t extF80M_to_ui64_r_minMag( const extFloat80_t *, bool );
 int_fast32_t extF80M_to_i32_r_minMag( const extFloat80_t *, bool );
 int_fast64_t extF80M_to_i64_r_minMag( const extFloat80_t *, bool );
-float16_t extF80M_to_f16( const extFloat80_t * );
-float32_t extF80M_to_f32( const extFloat80_t * );
-float64_t extF80M_to_f64( const extFloat80_t * );
-void extF80M_to_f128M( const extFloat80_t *, float128_t * );
+softfloat16_t extF80M_to_f16( const extFloat80_t * );
+softfloat32_t extF80M_to_f32( const extFloat80_t * );
+softfloat64_t extF80M_to_f64( const extFloat80_t * );
+void extF80M_to_f128M( const extFloat80_t *, softfloat128_t * );
 void
  extF80M_roundToInt(
      const extFloat80_t *, uint_fast8_t, bool, extFloat80_t * );
@@ -309,64 +309,64 @@ bool extF80M_isSignalingNaN( const extFloat80_t * );
 | 128-bit (quadruple-precision) floating-point operations.
 *----------------------------------------------------------------------------*/
 #ifdef SOFTFLOAT_FAST_INT64
-uint_fast32_t f128_to_ui32( float128_t, uint_fast8_t, bool );
-uint_fast64_t f128_to_ui64( float128_t, uint_fast8_t, bool );
-int_fast32_t f128_to_i32( float128_t, uint_fast8_t, bool );
-int_fast64_t f128_to_i64( float128_t, uint_fast8_t, bool );
-uint_fast32_t f128_to_ui32_r_minMag( float128_t, bool );
-uint_fast64_t f128_to_ui64_r_minMag( float128_t, bool );
-int_fast32_t f128_to_i32_r_minMag( float128_t, bool );
-int_fast64_t f128_to_i64_r_minMag( float128_t, bool );
-float16_t f128_to_f16( float128_t );
-float32_t f128_to_f32( float128_t );
-float64_t f128_to_f64( float128_t );
-extFloat80_t f128_to_extF80( float128_t );
-float128_t f128_roundToInt( float128_t, uint_fast8_t, bool );
-float128_t f128_add( float128_t, float128_t );
-float128_t f128_sub( float128_t, float128_t );
-float128_t f128_mul( float128_t, float128_t );
-float128_t f128_mulAdd( float128_t, float128_t, float128_t );
-float128_t f128_div( float128_t, float128_t );
-float128_t f128_rem( float128_t, float128_t );
-float128_t f128_sqrt( float128_t );
-bool f128_eq( float128_t, float128_t );
-bool f128_le( float128_t, float128_t );
-bool f128_lt( float128_t, float128_t );
-bool f128_eq_signaling( float128_t, float128_t );
-bool f128_le_quiet( float128_t, float128_t );
-bool f128_lt_quiet( float128_t, float128_t );
-bool f128_isSignalingNaN( float128_t );
+uint_fast32_t f128_to_ui32( softfloat128_t, uint_fast8_t, bool );
+uint_fast64_t f128_to_ui64( softfloat128_t, uint_fast8_t, bool );
+int_fast32_t f128_to_i32( softfloat128_t, uint_fast8_t, bool );
+int_fast64_t f128_to_i64( softfloat128_t, uint_fast8_t, bool );
+uint_fast32_t f128_to_ui32_r_minMag( softfloat128_t, bool );
+uint_fast64_t f128_to_ui64_r_minMag( softfloat128_t, bool );
+int_fast32_t f128_to_i32_r_minMag( softfloat128_t, bool );
+int_fast64_t f128_to_i64_r_minMag( softfloat128_t, bool );
+softfloat16_t f128_to_f16( softfloat128_t );
+softfloat32_t f128_to_f32( softfloat128_t );
+softfloat64_t f128_to_f64( softfloat128_t );
+extFloat80_t f128_to_extF80( softfloat128_t );
+softfloat128_t f128_roundToInt( softfloat128_t, uint_fast8_t, bool );
+softfloat128_t f128_add( softfloat128_t, softfloat128_t );
+softfloat128_t f128_sub( softfloat128_t, softfloat128_t );
+softfloat128_t f128_mul( softfloat128_t, softfloat128_t );
+softfloat128_t f128_mulAdd( softfloat128_t, softfloat128_t, softfloat128_t );
+softfloat128_t f128_div( softfloat128_t, softfloat128_t );
+softfloat128_t f128_rem( softfloat128_t, softfloat128_t );
+softfloat128_t f128_sqrt( softfloat128_t );
+bool f128_eq( softfloat128_t, softfloat128_t );
+bool f128_le( softfloat128_t, softfloat128_t );
+bool f128_lt( softfloat128_t, softfloat128_t );
+bool f128_eq_signaling( softfloat128_t, softfloat128_t );
+bool f128_le_quiet( softfloat128_t, softfloat128_t );
+bool f128_lt_quiet( softfloat128_t, softfloat128_t );
+bool f128_isSignalingNaN( softfloat128_t );
 #endif
-uint_fast32_t f128M_to_ui32( const float128_t *, uint_fast8_t, bool );
-uint_fast64_t f128M_to_ui64( const float128_t *, uint_fast8_t, bool );
-int_fast32_t f128M_to_i32( const float128_t *, uint_fast8_t, bool );
-int_fast64_t f128M_to_i64( const float128_t *, uint_fast8_t, bool );
-uint_fast32_t f128M_to_ui32_r_minMag( const float128_t *, bool );
-uint_fast64_t f128M_to_ui64_r_minMag( const float128_t *, bool );
-int_fast32_t f128M_to_i32_r_minMag( const float128_t *, bool );
-int_fast64_t f128M_to_i64_r_minMag( const float128_t *, bool );
-float16_t f128M_to_f16( const float128_t * );
-float32_t f128M_to_f32( const float128_t * );
-float64_t f128M_to_f64( const float128_t * );
-void f128M_to_extF80M( const float128_t *, extFloat80_t * );
-void f128M_roundToInt( const float128_t *, uint_fast8_t, bool, float128_t * );
-void f128M_add( const float128_t *, const float128_t *, float128_t * );
-void f128M_sub( const float128_t *, const float128_t *, float128_t * );
-void f128M_mul( const float128_t *, const float128_t *, float128_t * );
+uint_fast32_t f128M_to_ui32( const softfloat128_t *, uint_fast8_t, bool );
+uint_fast64_t f128M_to_ui64( const softfloat128_t *, uint_fast8_t, bool );
+int_fast32_t f128M_to_i32( const softfloat128_t *, uint_fast8_t, bool );
+int_fast64_t f128M_to_i64( const softfloat128_t *, uint_fast8_t, bool );
+uint_fast32_t f128M_to_ui32_r_minMag( const softfloat128_t *, bool );
+uint_fast64_t f128M_to_ui64_r_minMag( const softfloat128_t *, bool );
+int_fast32_t f128M_to_i32_r_minMag( const softfloat128_t *, bool );
+int_fast64_t f128M_to_i64_r_minMag( const softfloat128_t *, bool );
+softfloat16_t f128M_to_f16( const softfloat128_t * );
+softfloat32_t f128M_to_f32( const softfloat128_t * );
+softfloat64_t f128M_to_f64( const softfloat128_t * );
+void f128M_to_extF80M( const softfloat128_t *, extFloat80_t * );
+void f128M_roundToInt( const softfloat128_t *, uint_fast8_t, bool, softfloat128_t * );
+void f128M_add( const softfloat128_t *, const softfloat128_t *, softfloat128_t * );
+void f128M_sub( const softfloat128_t *, const softfloat128_t *, softfloat128_t * );
+void f128M_mul( const softfloat128_t *, const softfloat128_t *, softfloat128_t * );
 void
  f128M_mulAdd(
-     const float128_t *, const float128_t *, const float128_t *, float128_t *
+     const softfloat128_t *, const softfloat128_t *, const softfloat128_t *, softfloat128_t *
  );
-void f128M_div( const float128_t *, const float128_t *, float128_t * );
-void f128M_rem( const float128_t *, const float128_t *, float128_t * );
-void f128M_sqrt( const float128_t *, float128_t * );
-bool f128M_eq( const float128_t *, const float128_t * );
-bool f128M_le( const float128_t *, const float128_t * );
-bool f128M_lt( const float128_t *, const float128_t * );
-bool f128M_eq_signaling( const float128_t *, const float128_t * );
-bool f128M_le_quiet( const float128_t *, const float128_t * );
-bool f128M_lt_quiet( const float128_t *, const float128_t * );
-bool f128M_isSignalingNaN( const float128_t * );
+void f128M_div( const softfloat128_t *, const softfloat128_t *, softfloat128_t * );
+void f128M_rem( const softfloat128_t *, const softfloat128_t *, softfloat128_t * );
+void f128M_sqrt( const softfloat128_t *, softfloat128_t * );
+bool f128M_eq( const softfloat128_t *, const softfloat128_t * );
+bool f128M_le( const softfloat128_t *, const softfloat128_t * );
+bool f128M_lt( const softfloat128_t *, const softfloat128_t * );
+bool f128M_eq_signaling( const softfloat128_t *, const softfloat128_t * );
+bool f128M_le_quiet( const softfloat128_t *, const softfloat128_t * );
+bool f128M_lt_quiet( const softfloat128_t *, const softfloat128_t * );
+bool f128M_isSignalingNaN( const softfloat128_t * );
 
 #endif
 

--- a/source/include/softfloat.hpp
+++ b/source/include/softfloat.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstring>
 #include <softfloat_types.h>
 
 #ifndef THREAD_LOCAL
@@ -9,306 +10,306 @@ extern "C" {
 /*----------------------------------------------------------------------------
 | Integer-to-floating-point conversion routines.
 *----------------------------------------------------------------------------*/
-float16_t ui32_to_f16( uint32_t );
-float32_t ui32_to_f32( uint32_t );
-float64_t ui32_to_f64( uint32_t );
-float128_t ui32_to_f128( uint32_t );
-void ui32_to_f128M( uint32_t, float128_t * );
-float16_t ui64_to_f16( uint64_t );
-float32_t ui64_to_f32( uint64_t );
-float64_t ui64_to_f64( uint64_t );
-float128_t ui64_to_f128( uint64_t );
-void ui64_to_f128M( uint64_t, float128_t * );
-float16_t i32_to_f16( int32_t );
-float32_t i32_to_f32( int32_t );
-float64_t i32_to_f64( int32_t );
-float128_t i32_to_f128( int32_t );
-void i32_to_f128M( int32_t, float128_t * );
-float16_t i64_to_f16( int64_t );
-float32_t i64_to_f32( int64_t );
-float64_t i64_to_f64( int64_t );
-float128_t i64_to_f128( int64_t );
-void i64_to_f128M( int64_t, float128_t * );
+softfloat16_t ui32_to_f16( uint32_t );
+softfloat32_t ui32_to_f32( uint32_t );
+softfloat64_t ui32_to_f64( uint32_t );
+softfloat128_t ui32_to_f128( uint32_t );
+void ui32_to_f128M( uint32_t, softfloat128_t * );
+softfloat16_t ui64_to_f16( uint64_t );
+softfloat32_t ui64_to_f32( uint64_t );
+softfloat64_t ui64_to_f64( uint64_t );
+softfloat128_t ui64_to_f128( uint64_t );
+void ui64_to_f128M( uint64_t, softfloat128_t * );
+softfloat16_t i32_to_f16( int32_t );
+softfloat32_t i32_to_f32( int32_t );
+softfloat64_t i32_to_f64( int32_t );
+softfloat128_t i32_to_f128( int32_t );
+void i32_to_f128M( int32_t, softfloat128_t * );
+softfloat16_t i64_to_f16( int64_t );
+softfloat32_t i64_to_f32( int64_t );
+softfloat64_t i64_to_f64( int64_t );
+softfloat128_t i64_to_f128( int64_t );
+void i64_to_f128M( int64_t, softfloat128_t * );
 
 /*----------------------------------------------------------------------------
 | 16-bit (half-precision) floating-point operations.
 *----------------------------------------------------------------------------*/
-uint_fast32_t f16_to_ui32( float16_t, uint_fast8_t, bool );
-uint_fast64_t f16_to_ui64( float16_t, uint_fast8_t, bool );
-int_fast32_t f16_to_i32( float16_t, uint_fast8_t, bool );
-int_fast64_t f16_to_i64( float16_t, uint_fast8_t, bool );
-uint_fast32_t f16_to_ui32_r_minMag( float16_t, bool );
-uint_fast64_t f16_to_ui64_r_minMag( float16_t, bool );
-int_fast32_t f16_to_i32_r_minMag( float16_t, bool );
-int_fast64_t f16_to_i64_r_minMag( float16_t, bool );
-float32_t f16_to_f32( float16_t );
-float64_t f16_to_f64( float16_t );
-float128_t f16_to_f128( float16_t );
-void f16_to_f128M( float16_t, float128_t * );
-float16_t f16_roundToInt( float16_t, uint_fast8_t, bool );
-float16_t f16_add( float16_t, float16_t );
-float16_t f16_sub( float16_t, float16_t );
-float16_t f16_mul( float16_t, float16_t );
-float16_t f16_mulAdd( float16_t, float16_t, float16_t );
-float16_t f16_div( float16_t, float16_t );
-float16_t f16_rem( float16_t, float16_t );
-float16_t f16_sqrt( float16_t );
-bool f16_eq( float16_t, float16_t );
-bool f16_le( float16_t, float16_t );
-bool f16_lt( float16_t, float16_t );
-bool f16_eq_signaling( float16_t, float16_t );
-bool f16_le_quiet( float16_t, float16_t );
-bool f16_lt_quiet( float16_t, float16_t );
-bool f16_isSignalingNaN( float16_t );
+uint_fast32_t f16_to_ui32( softfloat16_t, uint_fast8_t, bool );
+uint_fast64_t f16_to_ui64( softfloat16_t, uint_fast8_t, bool );
+int_fast32_t f16_to_i32( softfloat16_t, uint_fast8_t, bool );
+int_fast64_t f16_to_i64( softfloat16_t, uint_fast8_t, bool );
+uint_fast32_t f16_to_ui32_r_minMag( softfloat16_t, bool );
+uint_fast64_t f16_to_ui64_r_minMag( softfloat16_t, bool );
+int_fast32_t f16_to_i32_r_minMag( softfloat16_t, bool );
+int_fast64_t f16_to_i64_r_minMag( softfloat16_t, bool );
+softfloat32_t f16_to_f32( softfloat16_t );
+softfloat64_t f16_to_f64( softfloat16_t );
+softfloat128_t f16_to_f128( softfloat16_t );
+void f16_to_f128M( softfloat16_t, softfloat128_t * );
+softfloat16_t f16_roundToInt( softfloat16_t, uint_fast8_t, bool );
+softfloat16_t f16_add( softfloat16_t, softfloat16_t );
+softfloat16_t f16_sub( softfloat16_t, softfloat16_t );
+softfloat16_t f16_mul( softfloat16_t, softfloat16_t );
+softfloat16_t f16_mulAdd( softfloat16_t, softfloat16_t, softfloat16_t );
+softfloat16_t f16_div( softfloat16_t, softfloat16_t );
+softfloat16_t f16_rem( softfloat16_t, softfloat16_t );
+softfloat16_t f16_sqrt( softfloat16_t );
+bool f16_eq( softfloat16_t, softfloat16_t );
+bool f16_le( softfloat16_t, softfloat16_t );
+bool f16_lt( softfloat16_t, softfloat16_t );
+bool f16_eq_signaling( softfloat16_t, softfloat16_t );
+bool f16_le_quiet( softfloat16_t, softfloat16_t );
+bool f16_lt_quiet( softfloat16_t, softfloat16_t );
+bool f16_isSignalingNaN( softfloat16_t );
 
 /*----------------------------------------------------------------------------
 | 32-bit (single-precision) floating-point operations.
 *----------------------------------------------------------------------------*/
-uint_fast32_t f32_to_ui32( float32_t, uint_fast8_t, bool );
-uint_fast64_t f32_to_ui64( float32_t, uint_fast8_t, bool );
-int_fast32_t f32_to_i32( float32_t, uint_fast8_t, bool );
-int_fast64_t f32_to_i64( float32_t, uint_fast8_t, bool );
-uint_fast32_t f32_to_ui32_r_minMag( float32_t, bool );
-uint_fast64_t f32_to_ui64_r_minMag( float32_t, bool );
-int_fast32_t f32_to_i32_r_minMag( float32_t, bool );
-int_fast64_t f32_to_i64_r_minMag( float32_t, bool );
-float16_t f32_to_f16( float32_t );
-float64_t f32_to_f64( float32_t );
-float128_t f32_to_f128( float32_t );
+uint_fast32_t f32_to_ui32( softfloat32_t, uint_fast8_t, bool );
+uint_fast64_t f32_to_ui64( softfloat32_t, uint_fast8_t, bool );
+int_fast32_t f32_to_i32( softfloat32_t, uint_fast8_t, bool );
+int_fast64_t f32_to_i64( softfloat32_t, uint_fast8_t, bool );
+uint_fast32_t f32_to_ui32_r_minMag( softfloat32_t, bool );
+uint_fast64_t f32_to_ui64_r_minMag( softfloat32_t, bool );
+int_fast32_t f32_to_i32_r_minMag( softfloat32_t, bool );
+int_fast64_t f32_to_i64_r_minMag( softfloat32_t, bool );
+softfloat16_t f32_to_f16( softfloat32_t );
+softfloat64_t f32_to_f64( softfloat32_t );
+softfloat128_t f32_to_f128( softfloat32_t );
 
-void f32_to_f128M( float32_t, float128_t * );
-float32_t f32_roundToInt( float32_t, uint_fast8_t, bool );
-float32_t f32_add( float32_t, float32_t );
-float32_t f32_sub( float32_t, float32_t );
-float32_t f32_mul( float32_t, float32_t );
-float32_t f32_mulAdd( float32_t, float32_t, float32_t );
-float32_t f32_div( float32_t, float32_t );
-float32_t f32_rem( float32_t, float32_t );
-float32_t f32_sqrt( float32_t );
-bool f32_eq( float32_t, float32_t );
-bool f32_le( float32_t, float32_t );
-bool f32_lt( float32_t, float32_t );
-bool f32_eq_signaling( float32_t, float32_t );
-bool f32_le_quiet( float32_t, float32_t );
-bool f32_lt_quiet( float32_t, float32_t );
-bool f32_isSignalingNaN( float32_t );
+void f32_to_f128M( softfloat32_t, softfloat128_t * );
+softfloat32_t f32_roundToInt( softfloat32_t, uint_fast8_t, bool );
+softfloat32_t f32_add( softfloat32_t, softfloat32_t );
+softfloat32_t f32_sub( softfloat32_t, softfloat32_t );
+softfloat32_t f32_mul( softfloat32_t, softfloat32_t );
+softfloat32_t f32_mulAdd( softfloat32_t, softfloat32_t, softfloat32_t );
+softfloat32_t f32_div( softfloat32_t, softfloat32_t );
+softfloat32_t f32_rem( softfloat32_t, softfloat32_t );
+softfloat32_t f32_sqrt( softfloat32_t );
+bool f32_eq( softfloat32_t, softfloat32_t );
+bool f32_le( softfloat32_t, softfloat32_t );
+bool f32_lt( softfloat32_t, softfloat32_t );
+bool f32_eq_signaling( softfloat32_t, softfloat32_t );
+bool f32_le_quiet( softfloat32_t, softfloat32_t );
+bool f32_lt_quiet( softfloat32_t, softfloat32_t );
+bool f32_isSignalingNaN( softfloat32_t );
 
 /*----------------------------------------------------------------------------
 | 64-bit (double-precision) floating-point operations.
 *----------------------------------------------------------------------------*/
-uint_fast32_t f64_to_ui32( float64_t, uint_fast8_t, bool );
-uint_fast64_t f64_to_ui64( float64_t, uint_fast8_t, bool );
-int_fast32_t f64_to_i32( float64_t, uint_fast8_t, bool );
-int_fast64_t f64_to_i64( float64_t, uint_fast8_t, bool );
-uint_fast32_t f64_to_ui32_r_minMag( float64_t, bool );
-uint_fast64_t f64_to_ui64_r_minMag( float64_t, bool );
-int_fast32_t f64_to_i32_r_minMag( float64_t, bool );
-int_fast64_t f64_to_i64_r_minMag( float64_t, bool );
-float16_t f64_to_f16( float64_t );
-float32_t f64_to_f32( float64_t );
-float128_t f64_to_f128( float64_t );
-void f64_to_f128M( float64_t, float128_t * );
-float64_t f64_roundToInt( float64_t, uint_fast8_t, bool );
-float64_t f64_add( float64_t, float64_t );
-float64_t f64_sub( float64_t, float64_t );
-float64_t f64_mul( float64_t, float64_t );
-float64_t f64_mulAdd( float64_t, float64_t, float64_t );
-float64_t f64_div( float64_t, float64_t );
-float64_t f64_rem( float64_t, float64_t );
-float64_t f64_sqrt( float64_t );
-bool f64_eq( float64_t, float64_t );
-bool f64_le( float64_t, float64_t );
-bool f64_lt( float64_t, float64_t );
-bool f64_eq_signaling( float64_t, float64_t );
-bool f64_le_quiet( float64_t, float64_t );
-bool f64_lt_quiet( float64_t, float64_t );
-bool f64_isSignalingNaN( float64_t );
+uint_fast32_t f64_to_ui32( softfloat64_t, uint_fast8_t, bool );
+uint_fast64_t f64_to_ui64( softfloat64_t, uint_fast8_t, bool );
+int_fast32_t f64_to_i32( softfloat64_t, uint_fast8_t, bool );
+int_fast64_t f64_to_i64( softfloat64_t, uint_fast8_t, bool );
+uint_fast32_t f64_to_ui32_r_minMag( softfloat64_t, bool );
+uint_fast64_t f64_to_ui64_r_minMag( softfloat64_t, bool );
+int_fast32_t f64_to_i32_r_minMag( softfloat64_t, bool );
+int_fast64_t f64_to_i64_r_minMag( softfloat64_t, bool );
+softfloat16_t f64_to_f16( softfloat64_t );
+softfloat32_t f64_to_f32( softfloat64_t );
+softfloat128_t f64_to_f128( softfloat64_t );
+void f64_to_f128M( softfloat64_t, softfloat128_t * );
+softfloat64_t f64_roundToInt( softfloat64_t, uint_fast8_t, bool );
+softfloat64_t f64_add( softfloat64_t, softfloat64_t );
+softfloat64_t f64_sub( softfloat64_t, softfloat64_t );
+softfloat64_t f64_mul( softfloat64_t, softfloat64_t );
+softfloat64_t f64_mulAdd( softfloat64_t, softfloat64_t, softfloat64_t );
+softfloat64_t f64_div( softfloat64_t, softfloat64_t );
+softfloat64_t f64_rem( softfloat64_t, softfloat64_t );
+softfloat64_t f64_sqrt( softfloat64_t );
+bool f64_eq( softfloat64_t, softfloat64_t );
+bool f64_le( softfloat64_t, softfloat64_t );
+bool f64_lt( softfloat64_t, softfloat64_t );
+bool f64_eq_signaling( softfloat64_t, softfloat64_t );
+bool f64_le_quiet( softfloat64_t, softfloat64_t );
+bool f64_lt_quiet( softfloat64_t, softfloat64_t );
+bool f64_isSignalingNaN( softfloat64_t );
 
 /*----------------------------------------------------------------------------
 | 128-bit (quadruple-precision) floating-point operations.
 *----------------------------------------------------------------------------*/
-uint_fast32_t f128_to_ui32( float128_t, uint_fast8_t, bool );
-uint_fast64_t f128_to_ui64( float128_t, uint_fast8_t, bool );
-int_fast32_t f128_to_i32( float128_t, uint_fast8_t, bool );
-int_fast64_t f128_to_i64( float128_t, uint_fast8_t, bool );
-uint_fast32_t f128_to_ui32_r_minMag( float128_t, bool );
-uint_fast64_t f128_to_ui64_r_minMag( float128_t, bool );
-int_fast32_t f128_to_i32_r_minMag( float128_t, bool );
-int_fast64_t f128_to_i64_r_minMag( float128_t, bool );
-float16_t f128_to_f16( float128_t );
-float32_t f128_to_f32( float128_t );
-float64_t f128_to_f64( float128_t );
-float128_t f128_roundToInt( float128_t, uint_fast8_t, bool );
-float128_t f128_add( float128_t, float128_t );
-float128_t f128_sub( float128_t, float128_t );
-float128_t f128_mul( float128_t, float128_t );
-float128_t f128_mulAdd( float128_t, float128_t, float128_t );
-float128_t f128_div( float128_t, float128_t );
-float128_t f128_rem( float128_t, float128_t );
-float128_t f128_sqrt( float128_t );
-bool f128_eq( float128_t, float128_t );
-bool f128_le( float128_t, float128_t );
-bool f128_lt( float128_t, float128_t );
-bool f128_eq_signaling( float128_t, float128_t );
-bool f128_le_quiet( float128_t, float128_t );
-bool f128_lt_quiet( float128_t, float128_t );
-bool f128_isSignalingNaN( float128_t );
+uint_fast32_t f128_to_ui32( softfloat128_t, uint_fast8_t, bool );
+uint_fast64_t f128_to_ui64( softfloat128_t, uint_fast8_t, bool );
+int_fast32_t f128_to_i32( softfloat128_t, uint_fast8_t, bool );
+int_fast64_t f128_to_i64( softfloat128_t, uint_fast8_t, bool );
+uint_fast32_t f128_to_ui32_r_minMag( softfloat128_t, bool );
+uint_fast64_t f128_to_ui64_r_minMag( softfloat128_t, bool );
+int_fast32_t f128_to_i32_r_minMag( softfloat128_t, bool );
+int_fast64_t f128_to_i64_r_minMag( softfloat128_t, bool );
+softfloat16_t f128_to_f16( softfloat128_t );
+softfloat32_t f128_to_f32( softfloat128_t );
+softfloat64_t f128_to_f64( softfloat128_t );
+softfloat128_t f128_roundToInt( softfloat128_t, uint_fast8_t, bool );
+softfloat128_t f128_add( softfloat128_t, softfloat128_t );
+softfloat128_t f128_sub( softfloat128_t, softfloat128_t );
+softfloat128_t f128_mul( softfloat128_t, softfloat128_t );
+softfloat128_t f128_mulAdd( softfloat128_t, softfloat128_t, softfloat128_t );
+softfloat128_t f128_div( softfloat128_t, softfloat128_t );
+softfloat128_t f128_rem( softfloat128_t, softfloat128_t );
+softfloat128_t f128_sqrt( softfloat128_t );
+bool f128_eq( softfloat128_t, softfloat128_t );
+bool f128_le( softfloat128_t, softfloat128_t );
+bool f128_lt( softfloat128_t, softfloat128_t );
+bool f128_eq_signaling( softfloat128_t, softfloat128_t );
+bool f128_le_quiet( softfloat128_t, softfloat128_t );
+bool f128_lt_quiet( softfloat128_t, softfloat128_t );
+bool f128_isSignalingNaN( softfloat128_t );
 
-void f128M_to_extF80M( const float128_t *, extFloat80_t * );
-uint_fast32_t f128M_to_ui32( const float128_t *, uint_fast8_t, bool );
-uint_fast64_t f128M_to_ui64( const float128_t *, uint_fast8_t, bool );
-int_fast32_t f128M_to_i32( const float128_t *, uint_fast8_t, bool );
-int_fast64_t f128M_to_i64( const float128_t *, uint_fast8_t, bool );
-uint_fast32_t f128M_to_ui32_r_minMag( const float128_t *, bool );
-uint_fast64_t f128M_to_ui64_r_minMag( const float128_t *, bool );
-int_fast32_t f128M_to_i32_r_minMag( const float128_t *, bool );
-int_fast64_t f128M_to_i64_r_minMag( const float128_t *, bool );
-float16_t f128M_to_f16( const float128_t * );
-float32_t f128M_to_f32( const float128_t * );
-float64_t f128M_to_f64( const float128_t * );
-void f128M_roundToInt( const float128_t *, uint_fast8_t, bool, float128_t * );
-void f128M_add( const float128_t *, const float128_t *, float128_t * );
-void f128M_sub( const float128_t *, const float128_t *, float128_t * );
-void f128M_mul( const float128_t *, const float128_t *, float128_t * );
+void f128M_to_extF80M( const softfloat128_t *, extFloat80_t * );
+uint_fast32_t f128M_to_ui32( const softfloat128_t *, uint_fast8_t, bool );
+uint_fast64_t f128M_to_ui64( const softfloat128_t *, uint_fast8_t, bool );
+int_fast32_t f128M_to_i32( const softfloat128_t *, uint_fast8_t, bool );
+int_fast64_t f128M_to_i64( const softfloat128_t *, uint_fast8_t, bool );
+uint_fast32_t f128M_to_ui32_r_minMag( const softfloat128_t *, bool );
+uint_fast64_t f128M_to_ui64_r_minMag( const softfloat128_t *, bool );
+int_fast32_t f128M_to_i32_r_minMag( const softfloat128_t *, bool );
+int_fast64_t f128M_to_i64_r_minMag( const softfloat128_t *, bool );
+softfloat16_t f128M_to_f16( const softfloat128_t * );
+softfloat32_t f128M_to_f32( const softfloat128_t * );
+softfloat64_t f128M_to_f64( const softfloat128_t * );
+void f128M_roundToInt( const softfloat128_t *, uint_fast8_t, bool, softfloat128_t * );
+void f128M_add( const softfloat128_t *, const softfloat128_t *, softfloat128_t * );
+void f128M_sub( const softfloat128_t *, const softfloat128_t *, softfloat128_t * );
+void f128M_mul( const softfloat128_t *, const softfloat128_t *, softfloat128_t * );
 void
  f128M_mulAdd(
-     const float128_t *, const float128_t *, const float128_t *, float128_t *
+     const softfloat128_t *, const softfloat128_t *, const softfloat128_t *, softfloat128_t *
  );
-void f128M_div( const float128_t *, const float128_t *, float128_t * );
-void f128M_rem( const float128_t *, const float128_t *, float128_t * );
-void f128M_sqrt( const float128_t *, float128_t * );
-bool f128M_eq( const float128_t *, const float128_t * );
-bool f128M_le( const float128_t *, const float128_t * );
-bool f128M_lt( const float128_t *, const float128_t * );
-bool f128M_eq_signaling( const float128_t *, const float128_t * );
-bool f128M_le_quiet( const float128_t *, const float128_t * );
-bool f128M_lt_quiet( const float128_t *, const float128_t * );
-bool f128M_isSignalingNaN( const float128_t * );
-bool isNaNF128( const float128_t * );
+void f128M_div( const softfloat128_t *, const softfloat128_t *, softfloat128_t * );
+void f128M_rem( const softfloat128_t *, const softfloat128_t *, softfloat128_t * );
+void f128M_sqrt( const softfloat128_t *, softfloat128_t * );
+bool f128M_eq( const softfloat128_t *, const softfloat128_t * );
+bool f128M_le( const softfloat128_t *, const softfloat128_t * );
+bool f128M_lt( const softfloat128_t *, const softfloat128_t * );
+bool f128M_eq_signaling( const softfloat128_t *, const softfloat128_t * );
+bool f128M_le_quiet( const softfloat128_t *, const softfloat128_t * );
+bool f128M_lt_quiet( const softfloat128_t *, const softfloat128_t * );
+bool f128M_isSignalingNaN( const softfloat128_t * );
+bool isNaNF128( const softfloat128_t * );
 };
 
-inline bool operator == (const float32_t& lhs, const float32_t& rhs) {
+inline bool operator == (const softfloat32_t& lhs, const softfloat32_t& rhs) {
    return f32_eq(lhs, rhs);
 }
 
-inline bool operator != (const float32_t& lhs, const float32_t& rhs) {
+inline bool operator != (const softfloat32_t& lhs, const softfloat32_t& rhs) {
    return !f32_eq(lhs, rhs);
 }
 
-inline bool operator < (const float32_t& lhs, const float32_t& rhs) {
+inline bool operator < (const softfloat32_t& lhs, const softfloat32_t& rhs) {
    return f32_lt(lhs, rhs);
 }
 
-inline bool operator > (const float32_t& lhs, const float32_t& rhs) {
+inline bool operator > (const softfloat32_t& lhs, const softfloat32_t& rhs) {
    return f32_lt(rhs, lhs);
 }
 
-inline bool operator <= (const float32_t& lhs, const float32_t& rhs) {
+inline bool operator <= (const softfloat32_t& lhs, const softfloat32_t& rhs) {
    return f32_le(lhs, rhs);
 }
 
-inline bool operator >= (const float32_t& lhs, const float32_t& rhs) {
+inline bool operator >= (const softfloat32_t& lhs, const softfloat32_t& rhs) {
    return f32_le(rhs, lhs);
 }
 
-inline bool operator == (const float64_t& lhs, const float64_t& rhs) {
+inline bool operator == (const softfloat64_t& lhs, const softfloat64_t& rhs) {
    return f64_eq(lhs, rhs);
 }
 
-inline bool operator != (const float64_t& lhs, const float64_t& rhs) {
+inline bool operator != (const softfloat64_t& lhs, const softfloat64_t& rhs) {
    return !f64_eq(lhs, rhs);
 }
 
-inline bool operator < (const float64_t& lhs, const float64_t& rhs) {
+inline bool operator < (const softfloat64_t& lhs, const softfloat64_t& rhs) {
    return f64_lt(lhs, rhs);
 }
 
-inline bool operator > (const float64_t& lhs, const float64_t& rhs) {
+inline bool operator > (const softfloat64_t& lhs, const softfloat64_t& rhs) {
    return f64_lt(rhs, lhs);
 }
 
-inline bool operator <= (const float64_t& lhs, const float64_t& rhs) {
+inline bool operator <= (const softfloat64_t& lhs, const softfloat64_t& rhs) {
    return f64_le(lhs, rhs);
 }
 
-inline bool operator >= (const float64_t& lhs, const float64_t& rhs) {
+inline bool operator >= (const softfloat64_t& lhs, const softfloat64_t& rhs) {
    return f64_le(rhs, lhs);
 }
 
-inline bool operator == (const float128_t& lhs, const float128_t& rhs) {
+inline bool operator == (const softfloat128_t& lhs, const softfloat128_t& rhs) {
    return f128_eq(lhs, rhs);
 }
 
-inline bool operator != (const float128_t& lhs, const float128_t& rhs) {
+inline bool operator != (const softfloat128_t& lhs, const softfloat128_t& rhs) {
    return !f128_eq(lhs, rhs);
 }
 
-inline bool operator < (const float128_t& lhs, const float128_t& rhs) {
+inline bool operator < (const softfloat128_t& lhs, const softfloat128_t& rhs) {
    return f128_lt(lhs, rhs);
 }
 
-inline bool operator > (const float128_t& lhs, const float128_t& rhs) {
+inline bool operator > (const softfloat128_t& lhs, const softfloat128_t& rhs) {
    return f128_lt(rhs, lhs);
 }
 
-inline bool operator <= (const float128_t& lhs, const float128_t& rhs) {
+inline bool operator <= (const softfloat128_t& lhs, const softfloat128_t& rhs) {
    return f128_le(lhs, rhs);
 }
 
-inline bool operator >= (const float128_t& lhs, const float128_t& rhs) {
+inline bool operator >= (const softfloat128_t& lhs, const softfloat128_t& rhs) {
    return f128_le(rhs, lhs);
 }
 
-inline bool f32_sign_bit( float32_t f )   { return f.v >> 31; }
-inline bool f64_sign_bit( float64_t f )   { return f.v >> 63; }
-inline bool f128_sign_bit( float128_t f ) { return f.v[1] >> 63; }
+inline bool f32_sign_bit( softfloat32_t f )   { return f.v >> 31; }
+inline bool f64_sign_bit( softfloat64_t f )   { return f.v >> 63; }
+inline bool f128_sign_bit( softfloat128_t f ) { return f.v[1] >> 63; }
 
-inline bool f32_is_nan( const float32_t f ) {
+inline bool f32_is_nan( const softfloat32_t f ) {
    return ((f.v & 0x7FFFFFFF) > 0x7F800000);
 }
-inline bool f64_is_nan( const float64_t f ) {
+inline bool f64_is_nan( const softfloat64_t f ) {
    return ((f.v & 0x7FFFFFFFFFFFFFFF) > 0x7FF0000000000000);
 }
-inline bool f128_is_nan( const float128_t& f ) {
+inline bool f128_is_nan( const softfloat128_t& f ) {
    return (((~(f.v[1]) & uint64_t( 0x7FFF000000000000 )) == 0) && (f.v[0] || ((f.v[1]) & uint64_t( 0x0000FFFFFFFFFFFF ))));
 }
 
-inline float32_t f32_negative_infinity() {
+inline softfloat32_t f32_negative_infinity() {
    return {0xff800000ul};
 }
-inline float32_t f32_positive_infinity() {
+inline softfloat32_t f32_positive_infinity() {
    return {0x7f800000ul};
 }
-inline float64_t f64_negative_infinity() {
+inline softfloat64_t f64_negative_infinity() {
    return {0xfff0000000000000ull};
 }
-inline float64_t f64_positive_infinity() {
+inline softfloat64_t f64_positive_infinity() {
    return {0x7ff0000000000000ull};
 }
-inline float128_t f128_negative_infinity() {
+inline softfloat128_t f128_negative_infinity() {
    return {{0x0ull, 0xffff000000000000ull}};
 }
-inline float128_t f128_positive_infinity() {
+inline softfloat128_t f128_positive_infinity() {
    return {{0x0ull, 0x7fff000000000000ull}};
 }
 
-inline float32_t to_softfloat32( float f ) {
-   float32_t x;
-   memcpy(&x, &f, sizeof(f));
+inline softfloat32_t to_softfloat32( float f ) {
+   softfloat32_t x;
+   std::memcpy(&x, &f, sizeof(f));
    return x;
 }
-inline float64_t to_softfloat64( double d ) {
-   float64_t x;
-   memcpy(&x, &d, sizeof(d));
+inline softfloat64_t to_softfloat64( double d ) {
+   softfloat64_t x;
+   std::memcpy(&x, &d, sizeof(d));
    return x;
 }
-inline float from_softfloat32( float32_t f ) {
+inline float from_softfloat32( softfloat32_t f ) {
    float x;
-   memcpy(&x, &f, sizeof(f));
+   std::memcpy(&x, &f, sizeof(f));
    return x;
 }
-inline double from_softfloat64( float64_t d ) {
+inline double from_softfloat64( softfloat64_t d ) {
    double x;
-   memcpy(&x, &d, sizeof(d));
+   std::memcpy(&x, &d, sizeof(d));
    return x;
 }

--- a/source/include/softfloat_types.h
+++ b/source/include/softfloat_types.h
@@ -47,10 +47,34 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 | the types below may, if desired, be defined as aliases for the native types
 | (typically 'float' and 'double', and possibly 'long double').
 *----------------------------------------------------------------------------*/
-typedef struct { uint16_t v; } float16_t;
-typedef struct { uint32_t v; } float32_t;
-typedef struct { uint64_t v; } float64_t;
-typedef struct { uint64_t v[2]; } float128_t;
+typedef struct { uint16_t v; } softfloat16_t;
+typedef struct { uint32_t v; } softfloat32_t;
+typedef struct { uint64_t v; } softfloat64_t;
+typedef struct { uint64_t v[2]; } softfloat128_t;
+
+#if defined(__cplusplus)
+static_assert(sizeof(softfloat16_t) == 2, "softfloat16_t must be 16 bits");
+static_assert(sizeof(softfloat32_t) == 4, "softfloat32_t must be 32 bits");
+static_assert(sizeof(softfloat64_t) == 8, "softfloat64_t must be 64 bits");
+static_assert(sizeof(softfloat128_t) == 16, "softfloat128_t must be 128 bits");
+#elif defined(__STDC_VERSION__) && (201112L <= __STDC_VERSION__)
+_Static_assert(sizeof(softfloat16_t) == 2, "softfloat16_t must be 16 bits");
+_Static_assert(sizeof(softfloat32_t) == 4, "softfloat32_t must be 32 bits");
+_Static_assert(sizeof(softfloat64_t) == 8, "softfloat64_t must be 64 bits");
+_Static_assert(sizeof(softfloat128_t) == 16, "softfloat128_t must be 128 bits");
+#endif
+
+/*
+| Legacy aliases remain available by default for source compatibility.  The
+| CMake target disables them for Apple/Linux arm64 consumers, where these names
+| collide with NEON typedefs from platform headers.
+*----------------------------------------------------------------------------*/
+#ifndef SOFTFLOAT_DISABLE_LEGACY_TYPE_ALIASES
+typedef softfloat16_t float16_t;
+typedef softfloat32_t float32_t;
+typedef softfloat64_t float64_t;
+typedef softfloat128_t float128_t;
+#endif
 
 /*----------------------------------------------------------------------------
 | The format of an 80-bit extended floating-point number in memory.  This
@@ -78,4 +102,3 @@ struct extFloat80M { uint16_t signExp; uint64_t signif; };
 typedef struct extFloat80M extFloat80_t;
 
 #endif
-

--- a/source/s_addMagsF128.c
+++ b/source/s_addMagsF128.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "specialize.h"
 
-float128_t
+softfloat128_t
  softfloat_addMagsF128(
      uint_fast64_t uiA64,
      uint_fast64_t uiA0,

--- a/source/s_addMagsF16.c
+++ b/source/s_addMagsF16.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float16_t softfloat_addMagsF16( uint_fast16_t uiA, uint_fast16_t uiB )
+softfloat16_t softfloat_addMagsF16( uint_fast16_t uiA, uint_fast16_t uiB )
 {
     int_fast8_t expA;
     uint_fast16_t sigA;

--- a/source/s_addMagsF32.c
+++ b/source/s_addMagsF32.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "specialize.h"
 
-float32_t softfloat_addMagsF32( uint_fast32_t uiA, uint_fast32_t uiB )
+softfloat32_t softfloat_addMagsF32( uint_fast32_t uiA, uint_fast32_t uiB )
 {
     int_fast16_t expA;
     uint_fast32_t sigA;

--- a/source/s_addMagsF64.c
+++ b/source/s_addMagsF64.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "specialize.h"
 
-float64_t
+softfloat64_t
  softfloat_addMagsF64( uint_fast64_t uiA, uint_fast64_t uiB, bool signZ )
 {
     int_fast16_t expA;

--- a/source/s_mulAddF128.c
+++ b/source/s_mulAddF128.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float128_t
+softfloat128_t
  softfloat_mulAddF128(
      uint_fast64_t uiA64,
      uint_fast64_t uiA0,

--- a/source/s_mulAddF16.c
+++ b/source/s_mulAddF16.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float16_t
+softfloat16_t
  softfloat_mulAddF16(
      uint_fast16_t uiA, uint_fast16_t uiB, uint_fast16_t uiC, uint_fast8_t op )
 {

--- a/source/s_mulAddF32.c
+++ b/source/s_mulAddF32.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float32_t
+softfloat32_t
  softfloat_mulAddF32(
      uint_fast32_t uiA, uint_fast32_t uiB, uint_fast32_t uiC, uint_fast8_t op )
 {

--- a/source/s_mulAddF64.c
+++ b/source/s_mulAddF64.c
@@ -43,7 +43,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef SOFTFLOAT_FAST_INT64
 
-float64_t
+softfloat64_t
  softfloat_mulAddF64(
      uint_fast64_t uiA, uint_fast64_t uiB, uint_fast64_t uiC, uint_fast8_t op )
 {
@@ -243,7 +243,7 @@ float64_t
 
 #else
 
-float64_t
+softfloat64_t
  softfloat_mulAddF64(
      uint_fast64_t uiA, uint_fast64_t uiB, uint_fast64_t uiC, uint_fast8_t op )
 {

--- a/source/s_normRoundPackToF128.c
+++ b/source/s_normRoundPackToF128.c
@@ -39,7 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "platform.h"
 #include "internals.h"
 
-float128_t
+softfloat128_t
  softfloat_normRoundPackToF128(
      bool sign, int_fast32_t exp, uint_fast64_t sig64, uint_fast64_t sig0 )
 {

--- a/source/s_normRoundPackToF16.c
+++ b/source/s_normRoundPackToF16.c
@@ -39,7 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "platform.h"
 #include "internals.h"
 
-float16_t
+softfloat16_t
  softfloat_normRoundPackToF16( bool sign, int_fast16_t exp, uint_fast16_t sig )
 {
     int_fast8_t shiftDist;

--- a/source/s_normRoundPackToF32.c
+++ b/source/s_normRoundPackToF32.c
@@ -39,7 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "platform.h"
 #include "internals.h"
 
-float32_t
+softfloat32_t
  softfloat_normRoundPackToF32( bool sign, int_fast16_t exp, uint_fast32_t sig )
 {
     int_fast8_t shiftDist;

--- a/source/s_normRoundPackToF64.c
+++ b/source/s_normRoundPackToF64.c
@@ -39,7 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "platform.h"
 #include "internals.h"
 
-float64_t
+softfloat64_t
  softfloat_normRoundPackToF64( bool sign, int_fast16_t exp, uint_fast64_t sig )
 {
     int_fast8_t shiftDist;

--- a/source/s_roundPackToF128.c
+++ b/source/s_roundPackToF128.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float128_t
+softfloat128_t
  softfloat_roundPackToF128(
      bool sign,
      int_fast32_t exp,

--- a/source/s_roundPackToF16.c
+++ b/source/s_roundPackToF16.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float16_t
+softfloat16_t
  softfloat_roundPackToF16( bool sign, int_fast16_t exp, uint_fast16_t sig )
 {
     uint_fast8_t roundingMode;

--- a/source/s_roundPackToF32.c
+++ b/source/s_roundPackToF32.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float32_t
+softfloat32_t
  softfloat_roundPackToF32( bool sign, int_fast16_t exp, uint_fast32_t sig )
 {
     uint_fast8_t roundingMode;

--- a/source/s_roundPackToF64.c
+++ b/source/s_roundPackToF64.c
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float64_t
+softfloat64_t
  softfloat_roundPackToF64( bool sign, int_fast16_t exp, uint_fast64_t sig )
 {
     uint_fast8_t roundingMode;

--- a/source/s_subMagsF128.c
+++ b/source/s_subMagsF128.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float128_t
+softfloat128_t
  softfloat_subMagsF128(
      uint_fast64_t uiA64,
      uint_fast64_t uiA0,

--- a/source/s_subMagsF16.c
+++ b/source/s_subMagsF16.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float16_t softfloat_subMagsF16( uint_fast16_t uiA, uint_fast16_t uiB )
+softfloat16_t softfloat_subMagsF16( uint_fast16_t uiA, uint_fast16_t uiB )
 {
     int_fast8_t expA;
     uint_fast16_t sigA;

--- a/source/s_subMagsF32.c
+++ b/source/s_subMagsF32.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float32_t softfloat_subMagsF32( uint_fast32_t uiA, uint_fast32_t uiB )
+softfloat32_t softfloat_subMagsF32( uint_fast32_t uiA, uint_fast32_t uiB )
 {
     int_fast16_t expA;
     uint_fast32_t sigA;

--- a/source/s_subMagsF64.c
+++ b/source/s_subMagsF64.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "specialize.h"
 #include "softfloat.h"
 
-float64_t
+softfloat64_t
  softfloat_subMagsF64( uint_fast64_t uiA, uint_fast64_t uiB, bool signZ )
 {
     int_fast16_t expA;

--- a/source/ui32_to_f128.c
+++ b/source/ui32_to_f128.c
@@ -39,7 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float128_t ui32_to_f128( uint32_t a )
+softfloat128_t ui32_to_f128( uint32_t a )
 {
     uint_fast64_t uiZ64;
     int_fast8_t shiftDist;

--- a/source/ui32_to_f128M.c
+++ b/source/ui32_to_f128M.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef SOFTFLOAT_FAST_INT64
 
-void ui32_to_f128M( uint32_t a, float128_t *zPtr )
+void ui32_to_f128M( uint32_t a, softfloat128_t *zPtr )
 {
 
     *zPtr = ui32_to_f128( a );
@@ -50,7 +50,7 @@ void ui32_to_f128M( uint32_t a, float128_t *zPtr )
 
 #else
 
-void ui32_to_f128M( uint32_t a, float128_t *zPtr )
+void ui32_to_f128M( uint32_t a, softfloat128_t *zPtr )
 {
     uint32_t *zWPtr, uiZ96, uiZ64;
     int_fast8_t shiftDist;

--- a/source/ui32_to_f16.c
+++ b/source/ui32_to_f16.c
@@ -39,7 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float16_t ui32_to_f16( uint32_t a )
+softfloat16_t ui32_to_f16( uint32_t a )
 {
     int_fast8_t shiftDist;
     union ui16_f16 u;

--- a/source/ui32_to_f32.c
+++ b/source/ui32_to_f32.c
@@ -39,7 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float32_t ui32_to_f32( uint32_t a )
+softfloat32_t ui32_to_f32( uint32_t a )
 {
     union ui32_f32 uZ;
 

--- a/source/ui32_to_f64.c
+++ b/source/ui32_to_f64.c
@@ -39,7 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float64_t ui32_to_f64( uint32_t a )
+softfloat64_t ui32_to_f64( uint32_t a )
 {
     uint_fast64_t uiZ;
     int_fast8_t shiftDist;

--- a/source/ui64_to_f128.c
+++ b/source/ui64_to_f128.c
@@ -39,7 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float128_t ui64_to_f128( uint64_t a )
+softfloat128_t ui64_to_f128( uint64_t a )
 {
     uint_fast64_t uiZ64, uiZ0;
     int_fast8_t shiftDist;

--- a/source/ui64_to_f128M.c
+++ b/source/ui64_to_f128M.c
@@ -41,7 +41,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef SOFTFLOAT_FAST_INT64
 
-void ui64_to_f128M( uint64_t a, float128_t *zPtr )
+void ui64_to_f128M( uint64_t a, softfloat128_t *zPtr )
 {
 
     *zPtr = ui64_to_f128( a );
@@ -50,7 +50,7 @@ void ui64_to_f128M( uint64_t a, float128_t *zPtr )
 
 #else
 
-void ui64_to_f128M( uint64_t a, float128_t *zPtr )
+void ui64_to_f128M( uint64_t a, softfloat128_t *zPtr )
 {
     uint32_t *zWPtr, uiZ96, uiZ64;
     uint_fast8_t shiftDist;

--- a/source/ui64_to_f16.c
+++ b/source/ui64_to_f16.c
@@ -39,7 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float16_t ui64_to_f16( uint64_t a )
+softfloat16_t ui64_to_f16( uint64_t a )
 {
     int_fast8_t shiftDist;
     union ui16_f16 u;

--- a/source/ui64_to_f32.c
+++ b/source/ui64_to_f32.c
@@ -39,7 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float32_t ui64_to_f32( uint64_t a )
+softfloat32_t ui64_to_f32( uint64_t a )
 {
     int_fast8_t shiftDist;
     union ui32_f32 u;

--- a/source/ui64_to_f64.c
+++ b/source/ui64_to_f64.c
@@ -39,7 +39,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "internals.h"
 #include "softfloat.h"
 
-float64_t ui64_to_f64( uint64_t a )
+softfloat64_t ui64_to_f64( uint64_t a )
 {
     union ui64_f64 uZ;
 

--- a/tests/softfloat_neon_include_order_reverse_test.cpp
+++ b/tests/softfloat_neon_include_order_reverse_test.cpp
@@ -1,0 +1,13 @@
+#include <softfloat/softfloat.hpp>
+#include <arm_neon.h>
+
+#ifndef SOFTFLOAT_DISABLE_LEGACY_TYPE_ALIASES
+#error "softfloat target must disable legacy aliases for NEON include-order safety"
+#endif
+
+// This translation unit intentionally has no main; it verifies the reverse
+// header order while sharing the executable's main with the forward-order test.
+static_assert(sizeof(softfloat16_t) == 2, "softfloat16_t must be 16 bits");
+static_assert(sizeof(softfloat32_t) == 4, "softfloat32_t must be 32 bits");
+static_assert(sizeof(softfloat64_t) == 8, "softfloat64_t must be 64 bits");
+static_assert(sizeof(softfloat128_t) == 16, "softfloat128_t must be 128 bits");

--- a/tests/softfloat_neon_include_order_test.cpp
+++ b/tests/softfloat_neon_include_order_test.cpp
@@ -1,0 +1,16 @@
+#include <arm_neon.h>
+#include <softfloat/softfloat.hpp>
+
+#ifndef SOFTFLOAT_DISABLE_LEGACY_TYPE_ALIASES
+#error "softfloat target must disable legacy aliases for NEON include-order safety"
+#endif
+
+static_assert(sizeof(softfloat16_t) == 2, "softfloat16_t must be 16 bits");
+static_assert(sizeof(softfloat32_t) == 4, "softfloat32_t must be 32 bits");
+static_assert(sizeof(softfloat64_t) == 8, "softfloat64_t must be 64 bits");
+static_assert(sizeof(softfloat128_t) == 16, "softfloat128_t must be 128 bits");
+
+int main()
+{
+    return 0;
+}


### PR DESCRIPTION
## Summary

Add non-conflicting SoftFloat public type names and arm64 CMake support so Apple Silicon consumers can include SoftFloat alongside NEON headers without typedef collisions.

## What changed

- Introduced canonical `softfloat16_t`, `softfloat32_t`, `softfloat64_t`, and `softfloat128_t` types with layout assertions.
- Kept legacy `float16_t`, `float32_t`, `float64_t`, and `float128_t` aliases by default behind `SOFTFLOAT_DISABLE_LEGACY_TYPE_ALIASES`.
- Updated public headers, the C++ wrapper, internals, and implementation sources to use canonical `softfloat*_t` names.
- Added architecture selection in CMake for wasm, x86_64, generic arm64, and Windows ARM64/MSVC.
- Added Apple/Linux arm64 include-order checks for `<arm_neon.h>` and `softfloat.hpp`.
- Suppressed intentional unused-label warnings in the SoftFloat C target.

## Why

Apple arm64 system headers can define `float16_t`, `float32_t`, and `float64_t` through `<arm_neon.h>`. If SoftFloat exposes those names first, downstream builds can fail with typedef redefinition errors. The canonical names avoid the collision while preserving compatibility for existing consumers that still use the legacy aliases.

## Testing

- `cmake -S . -B build/apple-arm64`
- `cmake --build build/apple-arm64 --target softfloat_neon_include_order_test`
- `build/apple-arm64/softfloat_neon_include_order_test`
- C compile smoke checks for default legacy aliases and `SOFTFLOAT_DISABLE_LEGACY_TYPE_ALIASES`

